### PR TITLE
1.2.0

### DIFF
--- a/src/Example/Program.cs
+++ b/src/Example/Program.cs
@@ -22,13 +22,16 @@ namespace Example
                     Name = "SourceCompanyName",
                     Revenue = 1234567,
                     StartDate = new DateTime(2020, 1, 1),
-                    SubCompanies = new List<Company>
+                    SubCompanies = new List<Company?>
                     {
                         new Company { Id = Guid.NewGuid(), Name = "SubCompany1", Revenue = 12, StartDate = new DateTime(2020, 2, 1) },
-                        new Company { Id = Guid.NewGuid(), Name = "SubCompany2", Revenue = 1234, StartDate = new DateTime(2020, 3, 1), SubCompanies = new List<Company>{
+                        default,
+                        new Company { Id = Guid.NewGuid(), Name = "SubCompany2", Revenue = 1234, StartDate = new DateTime(2020, 3, 1), SubCompanies = new List<Company?>{
                             new Company { Id = Guid.NewGuid(), Name = "SubCompany2a", Revenue = 123, StartDate = new DateTime(2020, 4, 1) },
+                            default,
                             new Company { Id = Guid.NewGuid(), Name = "SubCompany2b", Revenue = 234, StartDate = new DateTime(2020, 5, 1) },
-                        } },
+                        }},
+                        default
                     }
                 },
                 Metadata = new[] {
@@ -37,8 +40,6 @@ namespace Example
                         Data = Guid.NewGuid().ToString()
                     }}
             };
-
-            ;
 
             // important known limitation for source generators:
 

--- a/src/Example/Sources/Company.cs
+++ b/src/Example/Sources/Company.cs
@@ -15,6 +15,6 @@ namespace Example.Sources
 
         public string SomeData { get; set; }
 
-        public List<Company>? SubCompanies { get; set; }
+        public List<Company?>? SubCompanies { get; set; }
     }
 }

--- a/src/GeneratedMapper.Tests/CollectionMapperNullableElementsGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/CollectionMapperNullableElementsGeneratorTests.cs
@@ -1,0 +1,146 @@
+﻿using GeneratedMapper.Tests.Helpers;
+using NUnit.Framework;
+
+namespace GeneratedMapper.Tests
+{
+    public class CollectionMapperNullableElementsGeneratorTests
+    {
+        [Test]
+        public void MapElementsToNullableElements()
+        {
+            GeneratorTestHelper.TestGeneratedCode(@"using System;
+using System.Collections.Generic;
+using GeneratedMapper.Attributes;
+
+namespace A {
+    [MapTo(typeof(B.B))]
+    public class A { 
+        public IEnumerable<A> Obj { get; set; } 
+    }
+}
+
+namespace B {
+    public class B { public IEnumerable<B?> Obj { get; set; } }
+}
+}",
+@"using System;
+using System.Linq;
+
+#nullable enable
+
+namespace A
+{
+    public static partial class AMapToExtensions
+    {
+        public static B.B MapToB(this A.A self)
+        {
+            if (self is null)
+            {
+                throw new ArgumentNullException(nameof(self), ""A.A -> B.B: Source is null."");
+            }
+            
+            var target = new B.B
+            {
+                Obj = (self.Obj ?? throw new GeneratedMapper.Exceptions.PropertyNullException(""A.A -> B.B: Property 'Obj' is null."")).Select(element => element.MapToB()),
+            };
+            
+            return target;
+        }
+    }
+}
+");
+        }
+
+        [Test]
+        public void MapNullableElementsToNullableElements()
+        {
+            GeneratorTestHelper.TestGeneratedCode(@"using System;
+using System.Collections.Generic;
+using GeneratedMapper.Attributes;
+
+namespace A {
+    [MapTo(typeof(B.B))]
+    public class A { 
+        public IEnumerable<A?> Obj { get; set; } 
+    }
+}
+
+namespace B {
+    public class B { public IEnumerable<B?> Obj { get; set; } }
+}
+}",
+@"using System;
+using System.Linq;
+
+#nullable enable
+
+namespace A
+{
+    public static partial class AMapToExtensions
+    {
+        public static B.B MapToB(this A.A self)
+        {
+            if (self is null)
+            {
+                throw new ArgumentNullException(nameof(self), ""A.A -> B.B: Source is null."");
+            }
+            
+            var target = new B.B
+            {
+                Obj = (self.Obj ?? throw new GeneratedMapper.Exceptions.PropertyNullException(""A.A -> B.B: Property 'Obj' is null."")).Select(element => element?.MapToB()),
+            };
+            
+            return target;
+        }
+    }
+}
+");
+        }
+
+        [Test]
+        public void MapNullableElementsToElements()
+        {
+            GeneratorTestHelper.TestGeneratedCode(@"using System;
+using System.Collections.Generic;
+using GeneratedMapper.Attributes;
+
+namespace A {
+    [MapTo(typeof(B.B))]
+    public class A { 
+        public IEnumerable<A?> Obj { get; set; } 
+    }
+}
+
+namespace B {
+    public class B { public IEnumerable<B> Obj { get; set; } }
+}
+}",
+@"using System;
+using System.Linq;
+
+#nullable enable
+
+namespace A
+{
+    public static partial class AMapToExtensions
+    {
+        public static B.B MapToB(this A.A self)
+        {
+            if (self is null)
+            {
+                throw new ArgumentNullException(nameof(self), ""A.A -> B.B: Source is null."");
+            }
+            
+            var target = new B.B
+            {
+                Obj = (self.Obj ?? throw new GeneratedMapper.Exceptions.PropertyNullException(""A.A -> B.B: Property 'Obj' is null."")).Where(element => element is not null).Select(element => element!.MapToB()),
+            };
+            
+            return target;
+        }
+    }
+}
+");
+        }
+    }
+}

--- a/src/GeneratedMapper.Tests/Development/MappingBuilderDevelopmentTests.cs
+++ b/src/GeneratedMapper.Tests/Development/MappingBuilderDevelopmentTests.cs
@@ -446,7 +446,7 @@ namespace Namespace
             DoTest(mappingInformation,
                 new[]
                 {
-                    new PropertyMappingInformation(mappingInformation).MapFrom("Name", true, false).MapTo("Name", true, false).AsCollection(DestinationCollectionType.Array, "Namespace.DestinationItem")
+                    new PropertyMappingInformation(mappingInformation).MapFrom("Name", true, false).MapTo("Name", true, false).AsCollection(DestinationCollectionType.Array, "Namespace.DestinationItem", false, false)
                 },
                 @"using System;
 using System.Linq;

--- a/src/GeneratedMapper.Tests/Development/PropertyMappingBuilderDevelopmentTests.cs
+++ b/src/GeneratedMapper.Tests/Development/PropertyMappingBuilderDevelopmentTests.cs
@@ -101,28 +101,28 @@ namespace GeneratedMapper.Tests.Development
         public void NotNullableValueTypeToNotNullableValueType() => DoTest(true, new PropertyMappingInformation(_mappingInformation).MapFrom("x", false, true).MapTo("x", false, true));
 
         [Test]
-        public void SimpleMapperAsCollection() => DoTest(true, new PropertyMappingInformation(_mappingInformation).MapFrom("x", false, false).MapTo("x", false, false).AsCollection(DestinationCollectionType.Array, "x"));
+        public void SimpleMapperAsCollection() => DoTest(true, new PropertyMappingInformation(_mappingInformation).MapFrom("x", false, false).MapTo("x", false, false).AsCollection(DestinationCollectionType.Array, "x", false, false));
 
         [Test]
-        public void NotNullableToNullableAsCollection() => DoTest(true, new PropertyMappingInformation(_mappingInformation).MapFrom("x", false, false).MapTo("x", true, false).AsCollection(DestinationCollectionType.Array, "x"));
+        public void NotNullableToNullableAsCollection() => DoTest(true, new PropertyMappingInformation(_mappingInformation).MapFrom("x", false, false).MapTo("x", true, false).AsCollection(DestinationCollectionType.Array, "x", false, false));
 
         [Test]
-        public void NullableToNotNullableAsCollection() => DoTest(true, new PropertyMappingInformation(_mappingInformation).MapFrom("x", true, false).MapTo("x", false, false).AsCollection(DestinationCollectionType.Array, "x"));
+        public void NullableToNotNullableAsCollection() => DoTest(true, new PropertyMappingInformation(_mappingInformation).MapFrom("x", true, false).MapTo("x", false, false).AsCollection(DestinationCollectionType.Array, "x", false, false));
 
         [Test]
-        public void NullableToNullableAsCollection() => DoTest(true, new PropertyMappingInformation(_mappingInformation).MapFrom("x", true, false).MapTo("x", true, false).AsCollection(DestinationCollectionType.Array, "x"));
+        public void NullableToNullableAsCollection() => DoTest(true, new PropertyMappingInformation(_mappingInformation).MapFrom("x", true, false).MapTo("x", true, false).AsCollection(DestinationCollectionType.Array, "x", false, false));
 
         [Test]
-        public void ValidBaseAsCollectionWithoutMapping() => DoTest(true, _validBase.AsCollection(DestinationCollectionType.Array, "x"));
+        public void ValidBaseAsCollectionWithoutMapping() => DoTest(true, _validBase.AsCollection(DestinationCollectionType.Array, "x", false, false));
 
         [Test]
-        public void ValidBaseAsCollectionUsingMapper() => DoTest(true, _validBase.AsCollection(DestinationCollectionType.Array, "x").UsingMapper(_nestedSourceType.Object, _nestedDestinationType.Object).SetMappingInformation(_nestedMappingInformation));
+        public void ValidBaseAsCollectionUsingMapper() => DoTest(true, _validBase.AsCollection(DestinationCollectionType.Array, "x", false, false).UsingMapper(_nestedSourceType.Object, _nestedDestinationType.Object).SetMappingInformation(_nestedMappingInformation));
 
         [Test]
-        public void ValidBaseAsCollectionUsingMethod() => DoTest(true, _validBase.AsCollection(DestinationCollectionType.Array, "x").UsingMethod("x", "x", Enumerable.Empty<ParameterInformation>()));
+        public void ValidBaseAsCollectionUsingMethod() => DoTest(true, _validBase.AsCollection(DestinationCollectionType.Array, "x", false, false).UsingMethod("x", "x", Enumerable.Empty<ParameterInformation>()));
 
         [Test]
-        public void ValidBaseAsCollectionUsingResolver() => DoTest(true, _validBase.AsCollection(DestinationCollectionType.Array, "x").UsingResolver("x", "x", Enumerable.Empty<ParameterInformation>()));
+        public void ValidBaseAsCollectionUsingResolver() => DoTest(true, _validBase.AsCollection(DestinationCollectionType.Array, "x", false, false).UsingResolver("x", "x", Enumerable.Empty<ParameterInformation>()));
 
         [Test]
         public void ValidBaseUsingMapperWithoutMappingInformation() => DoTest(false, _validBase.UsingMapper(_nestedSourceType.Object, _nestedDestinationType.Object));

--- a/src/GeneratedMapper/Builders/PropertyMappingBuilder.cs
+++ b/src/GeneratedMapper/Builders/PropertyMappingBuilder.cs
@@ -56,26 +56,25 @@ namespace GeneratedMapper.Builders
                     : _information.CollectionType == DestinationCollectionType.Array ? ".ToArray()"
                     : string.Empty;
 
+                string selectExpression;
                 if (_information.MappingInformationOfMapperToUse != null && _information.MappingInformationOfMapperToUse.DestinationType != null)
                 {
-                    sourceExpression = $"{propertyRead}{safePropagationCollection}{optionalWhere}.Select(element => element{safePropagationElement}.MapTo{_information.MappingInformationOfMapperToUse.DestinationType.Name}({GetMappingArguments()})){enumerationMethod}";
+                    selectExpression = $".Select(element => element{safePropagationElement}.MapTo{_information.MappingInformationOfMapperToUse.DestinationType.Name}({GetMappingArguments()}))";
                 }
                 else if (_information.SourcePropertyMethodToCall != null)
                 {
-                    sourceExpression = $"{propertyRead}{safePropagationCollection}{optionalWhere}.Select(element => element{safePropagationElement}.{_information.SourcePropertyMethodToCall}({GetMethodArguments()})){enumerationMethod}";
+                    selectExpression = $".Select(element => element{safePropagationElement}.{_information.SourcePropertyMethodToCall}({GetMethodArguments()}))";
                 }
                 else if (_information.ResolverTypeToUse != null)
                 {
-                    sourceExpression = $"{propertyRead}{safePropagationCollection}{optionalWhere}.Select(element => {_information.ResolverInstanceName}.Resolve(element)){enumerationMethod}";
-                }
-                else if (!string.IsNullOrEmpty(enumerationMethod))
-                {
-                    sourceExpression = $"{propertyRead}{safePropagationCollection}{optionalWhere}{enumerationMethod}";
+                    selectExpression = $".Select(element => {_information.ResolverInstanceName}.Resolve(element))";
                 }
                 else
                 {
-                    sourceExpression = propertyRead;
+                    selectExpression = string.Empty;
                 }
+
+                sourceExpression = $"{propertyRead}{safePropagationCollection}{optionalWhere}{selectExpression}{enumerationMethod}";
             }
             else
             {

--- a/src/GeneratedMapper/GeneratedMapper.csproj
+++ b/src/GeneratedMapper/GeneratedMapper.csproj
@@ -5,7 +5,7 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>Thomas Bleijendaal</Authors>
     <Company>Thomas Bleijendaal</Company>
     <Product>Generated Mapper</Product>

--- a/src/GeneratedMapper/Information/PropertyMappingInformation.cs
+++ b/src/GeneratedMapper/Information/PropertyMappingInformation.cs
@@ -119,11 +119,16 @@ namespace GeneratedMapper.Information
 
         public DestinationCollectionType? CollectionType { get; private set; }
         public string? SourceCollectionItemTypeName { get; private set; }
+        public bool SourceCollectionItemNullable { get; private set; }
+        public bool DestinationCollectionItemNullable { get; private set; }
 
-        public PropertyMappingInformation AsCollection(DestinationCollectionType destinationCollectionType, string sourceItemTypeName)
+        public PropertyMappingInformation AsCollection(DestinationCollectionType destinationCollectionType, string sourceItemTypeName, bool sourceItemNullable, bool destinationItemNullable)
         {
             CollectionType = destinationCollectionType;
             SourceCollectionItemTypeName = sourceItemTypeName;
+
+            SourceCollectionItemNullable = sourceItemNullable;
+            DestinationCollectionItemNullable = destinationItemNullable;
 
             _namespacesRequired.Add("System.Linq");
 

--- a/src/GeneratedMapper/Parsers/PropertyParser.cs
+++ b/src/GeneratedMapper/Parsers/PropertyParser.cs
@@ -163,11 +163,13 @@ namespace GeneratedMapper.Parsers
         {
             var listType = DestinationCollectionType.Enumerable;
             var sourceCollectionItemType = GetCollectionType(sourceProperty);
+            ITypeSymbol destinationCollectionItemType;
             
             if (destinationProperty.Type.TypeKind == TypeKind.Array &&
                 destinationProperty.Type is IArrayTypeSymbol arrayDestinationProperty)
             {
                 listType = DestinationCollectionType.Array;
+                destinationCollectionItemType = arrayDestinationProperty.ElementType;
             }
             else if (destinationProperty.Type is INamedTypeSymbol namedDestinationPropertyType &&
                 namedDestinationPropertyType.IsGenericType &&
@@ -180,13 +182,22 @@ namespace GeneratedMapper.Parsers
                     : unboundGenericTypeInterfaces.Any(x => x.Equals(_genericReadOnlyListlikeType, SymbolEqualityComparer.Default)) ? DestinationCollectionType.List
                     : unboundGenericTypeInterfaces.Any(x => x.Equals(_genericEnumerableType, SymbolEqualityComparer.Default)) ? DestinationCollectionType.Enumerable
                     : DestinationCollectionType.Enumerable;
+
+                destinationCollectionItemType = namedDestinationPropertyType.TypeArguments.First();
+            }
+            else
+            {
+                // TODO: report collection item issue
+                return;
             }
 
             if (sourceCollectionItemType is not null)
             {
                 propertyMapping.AsCollection(
                     listType,
-                    sourceCollectionItemType.ToDisplayString());
+                    sourceCollectionItemType.ToDisplayString(),
+                    sourceCollectionItemType.NullableAnnotation == NullableAnnotation.Annotated,
+                    destinationCollectionItemType.NullableAnnotation == NullableAnnotation.Annotated);
             }
         }
     }


### PR DESCRIPTION
Elements of collections can be nullable, and when so the mapping either filters when the receiver cannot handle null elements, or includes them safely.