### PR TITLE
Move Index Bumping to use disposable for easy reading.

### DIFF
--- a/src/GeneratedMapper/Builders/Base/BuilderBase.cs
+++ b/src/GeneratedMapper/Builders/Base/BuilderBase.cs
@@ -2,6 +2,7 @@
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Linq;
+using GeneratedMapper.Helpers;
 using GeneratedMapper.Information;
 
 namespace GeneratedMapper.Builders.Base
@@ -64,33 +65,15 @@ namespace GeneratedMapper.Builders.Base
                 indentWriter.WriteLine();
             }
         }
-        protected void WriteOpenNamespaceAndStaticClass(IndentedTextWriter indentWriter, string extraNamespaceName, string className)
+        protected IDisposable WriteOpenNamespaceAndStaticClass(IndentedTextWriter indentWriter, string extraNamespaceName)
         {
             if (_information.SourceType != null && !_information.SourceType.ContainingNamespace.IsGlobalNamespace)
             {
                 indentWriter.WriteLine($"namespace {_information.SourceType.ContainingNamespace.ToDisplayString()}{extraNamespaceName}");
-                indentWriter.WriteLine("{");
-                indentWriter.Indent++;
+                return indentWriter.Braces();
             }
 
-            indentWriter.WriteLine($"public static partial class {className}");
-            indentWriter.WriteLine("{");
-            indentWriter.Indent++;
-        }
-
-        protected static void WriteCloseStaticClass(IndentedTextWriter indentWriter)
-        {
-            indentWriter.Indent--;
-            indentWriter.WriteLine("}");
-        }
-
-        protected void WriteCloseNamespace(IndentedTextWriter indentWriter)
-        {
-            if (_information.SourceType != null && !_information.SourceType.ContainingNamespace.IsGlobalNamespace)
-            {
-                indentWriter.Indent--;
-                indentWriter.WriteLine("}");
-            }
+            return indentWriter.NoIndent();
         }
 
         protected IEnumerable<string> GenerateCode<T>(IEnumerable<T> builders, Func<T, string?> mappingFeature)

--- a/src/GeneratedMapper/Builders/Base/BuilderBase.cs
+++ b/src/GeneratedMapper/Builders/Base/BuilderBase.cs
@@ -2,7 +2,7 @@
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Linq;
-using GeneratedMapper.Helpers;
+using GeneratedMapper.Extensions;
 using GeneratedMapper.Information;
 
 namespace GeneratedMapper.Builders.Base
@@ -65,7 +65,7 @@ namespace GeneratedMapper.Builders.Base
                 indentWriter.WriteLine();
             }
         }
-        protected IDisposable WriteOpenNamespaceAndStaticClass(IndentedTextWriter indentWriter, string extraNamespaceName)
+        protected IDisposable WriteOpenNamespace(IndentedTextWriter indentWriter, string extraNamespaceName)
         {
             if (_information.SourceType != null && !_information.SourceType.ContainingNamespace.IsGlobalNamespace)
             {

--- a/src/GeneratedMapper/Builders/ExpressionBuilder.cs
+++ b/src/GeneratedMapper/Builders/ExpressionBuilder.cs
@@ -5,7 +5,6 @@ using System.Text;
 using GeneratedMapper.Builders.Base;
 using GeneratedMapper.Enums;
 using GeneratedMapper.Extensions;
-using GeneratedMapper.Helpers;
 using GeneratedMapper.Information;
 using Microsoft.CodeAnalysis.Text;
 
@@ -32,7 +31,7 @@ namespace GeneratedMapper.Builders
                     .SelectMany(x => x.NamespacesUsed)),
                 allowNamespacesForAsync: false);
             WriteOptionalNullableEnablePragma(indentWriter);
-            using(WriteOpenNamespaceAndStaticClass(indentWriter, ".Expressions"))
+            using(WriteOpenNamespace(indentWriter, ".Expressions"))
             {
                 indentWriter.WriteLine($"public static partial class {_information.SourceType?.Name ?? ""}");
                 using (indentWriter.Braces())

--- a/src/GeneratedMapper/Builders/ExpressionBuilder.cs
+++ b/src/GeneratedMapper/Builders/ExpressionBuilder.cs
@@ -5,6 +5,7 @@ using System.Text;
 using GeneratedMapper.Builders.Base;
 using GeneratedMapper.Enums;
 using GeneratedMapper.Extensions;
+using GeneratedMapper.Helpers;
 using GeneratedMapper.Information;
 using Microsoft.CodeAnalysis.Text;
 
@@ -31,12 +32,14 @@ namespace GeneratedMapper.Builders
                     .SelectMany(x => x.NamespacesUsed)),
                 allowNamespacesForAsync: false);
             WriteOptionalNullableEnablePragma(indentWriter);
-            WriteOpenNamespaceAndStaticClass(indentWriter, ".Expressions", _information.SourceType?.Name ?? "");
-
-            WriteMethod(indentWriter);
-
-            WriteCloseStaticClass(indentWriter);
-            WriteCloseNamespace(indentWriter);
+            using(WriteOpenNamespaceAndStaticClass(indentWriter, ".Expressions"))
+            {
+                indentWriter.WriteLine($"public static partial class {_information.SourceType?.Name ?? ""}");
+                using (indentWriter.Braces())
+                {
+                    WriteMethod(indentWriter);
+                }
+            }
 
             return SourceText.From(writer.ToString(), Encoding.UTF8);
         }
@@ -46,13 +49,13 @@ namespace GeneratedMapper.Builders
             var mapParameters = _information.Mappings.Where(x => !x.IsAsync).SelectMany(x => x.MapParametersRequired.Select(x => x.ToMethodParameter(string.Empty))).Distinct();
 
             indentWriter.WriteLine($"public static Expression<Func<{_information.SourceType?.ToDisplayString()}, {_information.DestinationType?.ToDisplayString()}>> To{_information.DestinationType?.Name}({string.Join(", ", mapParameters)}) => ({_information.SourceType?.ToDisplayString()} {SourceInstanceName}) =>");
-            indentWriter.Indent++;
+            using (indentWriter.Indent())
+            {
+                var classBuilder = new ClassExpressionBuilder(new ExpressionContext<MappingInformation>(_information, SourceInstanceName, _maxRecursion));
 
-            var classBuilder = new ClassExpressionBuilder(new ExpressionContext<MappingInformation>(_information, SourceInstanceName, _maxRecursion));
-
-            classBuilder.WriteClass(indentWriter);
-            indentWriter.WriteLine(";");
-            indentWriter.Indent--;
+                classBuilder.WriteClass(indentWriter);
+                indentWriter.WriteLine(";");
+            }
         }
     }
 }

--- a/src/GeneratedMapper/Builders/InjectableMapperServiceCollectionRegistrationBuilder.cs
+++ b/src/GeneratedMapper/Builders/InjectableMapperServiceCollectionRegistrationBuilder.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using GeneratedMapper.Enums;
+using GeneratedMapper.Helpers;
 using GeneratedMapper.Information;
 using Microsoft.CodeAnalysis.Text;
 
@@ -29,43 +30,32 @@ namespace GeneratedMapper.Builders
             indentWriter.WriteLine("using System;");
             indentWriter.WriteLine();
             indentWriter.WriteLine("namespace Microsoft.Extensions.DependencyInjection");
-            indentWriter.WriteLine("{");
-            indentWriter.Indent++;
-
-            indentWriter.WriteLine("public static class GeneratedMapperExtensions");
-
-            indentWriter.WriteLine("{");
-            indentWriter.Indent++;
-
-            indentWriter.WriteLine("public static IServiceCollection AddMappers(this IServiceCollection services)");
-
-            indentWriter.WriteLine("{");
-            indentWriter.Indent++;
-
-            foreach (var mappingInformation in _injectables)
+            using (indentWriter.Braces())
             {
-                var className = $"{mappingInformation.SourceType?.Name}MapTo{mappingInformation.DestinationType?.Name}";
+                indentWriter.WriteLine("public static class GeneratedMapperExtensions");
+                using (indentWriter.Braces())
+                {
+                    indentWriter.WriteLine("public static IServiceCollection AddMappers(this IServiceCollection services)");
+                    using (indentWriter.Braces())
+                    {
+                        foreach (var mappingInformation in _injectables)
+                        {
+                            var className = $"{mappingInformation.SourceType?.Name}MapTo{mappingInformation.DestinationType?.Name}";
 
-                var fullClassName = (mappingInformation.SourceType?.ContainingNamespace.IsGlobalNamespace != true)
-                    ? $"{mappingInformation.SourceType?.ContainingNamespace.ToDisplayString()}.{className}"
-                    : className;
+                            var fullClassName = (mappingInformation.SourceType?.ContainingNamespace.IsGlobalNamespace != true)
+                                ? $"{mappingInformation.SourceType?.ContainingNamespace.ToDisplayString()}.{className}"
+                                : className;
 
-                var interfaceName = $"IMapper<{mappingInformation.SourceType?.ToDisplayString()}, {mappingInformation.DestinationType?.ToDisplayString()}>";
+                            var interfaceName = $"IMapper<{mappingInformation.SourceType?.ToDisplayString()}, {mappingInformation.DestinationType?.ToDisplayString()}>";
 
-                indentWriter.WriteLine($"services.AddTransient<{interfaceName}, {fullClassName}>();");
+                            indentWriter.WriteLine($"services.AddTransient<{interfaceName}, {fullClassName}>();");
+                        }
+
+                        indentWriter.WriteLine();
+                        indentWriter.WriteLine("return services;");
+                    }
+                }
             }
-
-            indentWriter.WriteLine();
-            indentWriter.WriteLine("return services;");
-
-            indentWriter.Indent--;
-            indentWriter.WriteLine("}");
-
-            indentWriter.Indent--;
-            indentWriter.WriteLine("}");
-
-            indentWriter.Indent--;
-            indentWriter.WriteLine("}");
 
             return SourceText.From(writer.ToString(), Encoding.UTF8);
         }

--- a/src/GeneratedMapper/Builders/InjectableMapperServiceCollectionRegistrationBuilder.cs
+++ b/src/GeneratedMapper/Builders/InjectableMapperServiceCollectionRegistrationBuilder.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using GeneratedMapper.Enums;
-using GeneratedMapper.Helpers;
+using GeneratedMapper.Extensions;
 using GeneratedMapper.Information;
 using Microsoft.CodeAnalysis.Text;
 

--- a/src/GeneratedMapper/Builders/MappingBuilder.cs
+++ b/src/GeneratedMapper/Builders/MappingBuilder.cs
@@ -6,7 +6,6 @@ using System.Text;
 using GeneratedMapper.Builders.Base;
 using GeneratedMapper.Enums;
 using GeneratedMapper.Extensions;
-using GeneratedMapper.Helpers;
 using GeneratedMapper.Information;
 using Microsoft.CodeAnalysis.Text;
 
@@ -29,7 +28,7 @@ namespace GeneratedMapper.Builders
 
             WriteUsingNamespaces(indentWriter, _propertyMappingBuilders.SelectMany(map => map.NamespacesUsed()));
             WriteOptionalNullableEnablePragma(indentWriter);
-            using (WriteOpenNamespaceAndStaticClass(indentWriter, ""))
+            using (WriteOpenNamespace(indentWriter, ""))
             {
                 indentWriter.WriteLine($"public static partial class {_information.SourceType?.Name}MapToExtensions");
                 using (indentWriter.Braces())

--- a/src/GeneratedMapper/Builders/MappingBuilder.cs
+++ b/src/GeneratedMapper/Builders/MappingBuilder.cs
@@ -6,6 +6,7 @@ using System.Text;
 using GeneratedMapper.Builders.Base;
 using GeneratedMapper.Enums;
 using GeneratedMapper.Extensions;
+using GeneratedMapper.Helpers;
 using GeneratedMapper.Information;
 using Microsoft.CodeAnalysis.Text;
 
@@ -28,17 +29,17 @@ namespace GeneratedMapper.Builders
 
             WriteUsingNamespaces(indentWriter, _propertyMappingBuilders.SelectMany(map => map.NamespacesUsed()));
             WriteOptionalNullableEnablePragma(indentWriter);
-            WriteOpenNamespaceAndStaticClass(indentWriter, "", $"{_information.SourceType?.Name}MapToExtensions");
+            using (WriteOpenNamespaceAndStaticClass(indentWriter, ""))
+            {
+                indentWriter.WriteLine($"public static partial class {_information.SourceType?.Name}MapToExtensions");
+                using (indentWriter.Braces())
+                {
+                    WriteMapToExtensionMethod(indentWriter);
 
-            WriteMapToExtensionMethod(indentWriter);
-
-            WriteEnumerableMapToExtensionMethod(indentWriter);
-
-            WriteCloseStaticClass(indentWriter);
-
-            WriteInjectableMapperClass(indentWriter);
-
-            WriteCloseNamespace(indentWriter);
+                    WriteEnumerableMapToExtensionMethod(indentWriter);
+                }
+                WriteInjectableMapperClass(indentWriter);
+            }
 
             return SourceText.From(writer.ToString(), Encoding.UTF8);
         }
@@ -53,40 +54,36 @@ namespace GeneratedMapper.Builders
 
             indentWriter.WriteLine($"public static {returnType} {extensionMethodName}({string.Join(", ", mapParameters)})");
 
-            indentWriter.WriteLine("{");
-            indentWriter.Indent++;
-
-            if (_information.SourceType != null && !_information.SourceType.IsValueType)
+            using (indentWriter.Braces())
             {
-                WriteNullCheck(indentWriter, SourceInstanceName, _information.SourceType.ToDisplayString(), _information.DestinationType?.ToDisplayString());
-            }
+                if (_information.SourceType != null && !_information.SourceType.IsValueType)
+                {
+                    WriteNullCheck(indentWriter, SourceInstanceName, _information.SourceType.ToDisplayString(), _information.DestinationType?.ToDisplayString());
+                }
 
-            indentWriter.WriteLines(GenerateCode(_propertyMappingBuilders, map => map.PreConstructionInitialization()), true);
+                indentWriter.WriteLines(GenerateCode(_propertyMappingBuilders, map => map.PreConstructionInitialization()), true);
 
-            indentWriter.WriteLine($"var {TargetInstanceName} = new {_information.DestinationType?.ToDisplayString()}");
-            indentWriter.WriteLine("{");
-            indentWriter.Indent++;
+                indentWriter.WriteLine($"var {TargetInstanceName} = new {_information.DestinationType?.ToDisplayString()}");
+                using (indentWriter.ClassSetters())
+                {
+                    indentWriter.WriteLines(GenerateCode(_propertyMappingBuilders, map => map.InitializerString()));
+                }
 
-            indentWriter.WriteLines(GenerateCode(_propertyMappingBuilders, map => map.InitializerString()));
-
-            indentWriter.Indent--;
-            indentWriter.WriteLine("};");
-            indentWriter.WriteLine();
-
-            if (_information.ConfigurationValues.Customizations.GenerateAfterMapPartial)
-            {
-                var partialArguments = new[] { SourceInstanceName }
-                    .Union(_propertyMappingBuilders.SelectMany(x => x.MapArgumentsRequired().Select(x => x.ToArgument(string.Empty))).Distinct())
-                    .Append(TargetInstanceName);
-
-                indentWriter.WriteLine($"After{extensionMethodName}({string.Join(", ", partialArguments)});");
                 indentWriter.WriteLine();
+
+                if (_information.ConfigurationValues.Customizations.GenerateAfterMapPartial)
+                {
+                    var partialArguments = new[] { SourceInstanceName }
+                        .Union(_propertyMappingBuilders.SelectMany(x => x.MapArgumentsRequired().Select(x => x.ToArgument(string.Empty))).Distinct())
+                        .Append(TargetInstanceName);
+
+                    indentWriter.WriteLine($"After{extensionMethodName}({string.Join(", ", partialArguments)});");
+                    indentWriter.WriteLine();
+                }
+
+                indentWriter.WriteLine($"return {TargetInstanceName};");
             }
-
-            indentWriter.WriteLine($"return {TargetInstanceName};");
-            indentWriter.Indent--;
-            indentWriter.WriteLine("}");
-
+            
             if (_information.ConfigurationValues.Customizations.GenerateAfterMapPartial)
             {
                 var partialParameters = new[] { $"{_information.SourceType?.ToDisplayString()} {PartialSourceInstanceName}" }
@@ -114,31 +111,26 @@ namespace GeneratedMapper.Builders
 
                 indentWriter.WriteLine();
                 indentWriter.WriteLine($"public static {enumerableType} {extensionMethodName}({string.Join(", ", mapEnumerableParameters)})");
-                indentWriter.WriteLine("{");
-                indentWriter.Indent++;
-
-                if (_information.SourceType != null && !_information.SourceType.IsValueType)
+                using (indentWriter.Braces())
                 {
-                    WriteNullCheck(indentWriter, SourceInstanceName, $"IEnumerable<{_information.SourceType.ToDisplayString()}>", $"IEnumerable<{_information.DestinationType?.ToDisplayString()}>");
-                }
+                    if (_information.SourceType != null && !_information.SourceType.IsValueType)
+                    {
+                        WriteNullCheck(indentWriter, SourceInstanceName, $"IEnumerable<{_information.SourceType.ToDisplayString()}>", $"IEnumerable<{_information.DestinationType?.ToDisplayString()}>");
+                    }
 
-                if (_information.IsAsync)
-                {
-                    indentWriter.WriteLine($"foreach (var element in {SourceInstanceName})");
-                    indentWriter.WriteLine("{");
-                    indentWriter.Indent++;
-
-                    indentWriter.WriteLine($"yield return await element.{extensionMethodName}({string.Join(", ", mapToArguments)});");
-
-                    indentWriter.Indent--;
-                    indentWriter.WriteLine("}");
+                    if (_information.IsAsync)
+                    {
+                        indentWriter.WriteLine($"foreach (var element in {SourceInstanceName})");
+                        using (indentWriter.Braces())
+                        {
+                            indentWriter.WriteLine($"yield return await element.{extensionMethodName}({string.Join(", ", mapToArguments)});");
+                        }
+                    }
+                    else
+                    {
+                        indentWriter.WriteLine($"return {SourceInstanceName}.Select(x => x.{extensionMethodName}({string.Join(", ", mapToArguments)}));");
+                    }
                 }
-                else
-                {
-                    indentWriter.WriteLine($"return {SourceInstanceName}.Select(x => x.{extensionMethodName}({string.Join(", ", mapToArguments)}));");
-                }
-                indentWriter.Indent--;
-                indentWriter.WriteLine("}");
             }
         }
 
@@ -154,57 +146,50 @@ namespace GeneratedMapper.Builders
 
                 indentWriter.WriteLine();
                 indentWriter.WriteLine($"public class {className} : IMapper<{_information.SourceType?.ToDisplayString()}, {_information.DestinationType?.ToDisplayString()}>");
-                indentWriter.WriteLine("{");
-                indentWriter.Indent++;
-
-                var constructorArguments = arguments.Select(x => x.ToMethodParameter(string.Empty)).Distinct();
-                var privateFields = arguments.Select(x => $"private readonly {x.TypeName} _{x.ParameterName};").Distinct();
-                var privateFieldAssignments = arguments.Select(x => $"_{x.ParameterName} = {x.ParameterName};").Distinct();
-                var mapParameters = arguments.Select(x => $"_{x.ParameterName}").Distinct();
-
-                if (constructorArguments.Any())
+                using (indentWriter.Braces())
                 {
-                    foreach (var privateField in privateFields)
+                    var constructorArguments = arguments.Select(x => x.ToMethodParameter(string.Empty)).Distinct();
+                    var privateFields = arguments.Select(x => $"private readonly {x.TypeName} _{x.ParameterName};").Distinct();
+                    var privateFieldAssignments = arguments.Select(x => $"_{x.ParameterName} = {x.ParameterName};").Distinct();
+                    var mapParameters = arguments.Select(x => $"_{x.ParameterName}").Distinct();
+
+                    if (constructorArguments.Any())
                     {
-                        indentWriter.WriteLine(privateField);
+                        foreach (var privateField in privateFields)
+                        {
+                            indentWriter.WriteLine(privateField);
+                        }
+
+                        indentWriter.WriteLine();
+
+                        indentWriter.WriteLine($"public {className}({string.Join(", ", constructorArguments)})");
+                        using (indentWriter.Braces())
+                        {
+                            foreach (var privateFieldAssignment in privateFieldAssignments)
+                            {
+                                indentWriter.WriteLine(privateFieldAssignment);
+                            }
+                        }
+                        indentWriter.WriteLine();
                     }
 
-                    indentWriter.WriteLine();
+                    var async = _information.IsAsync ? $"async " : $"";
+                    var callToMapMethod = _information.IsAsync
+                        ? $"await {fromExpression}.MapTo{_information.DestinationType?.Name}Async({string.Join(", ", mapParameters)})"
+                        : $"Task.FromResult({fromExpression}.MapTo{_information.DestinationType?.Name}({string.Join(", ", mapParameters)}))";
 
-                    indentWriter.WriteLine($"public {className}({string.Join(", ", constructorArguments)})");
-                    indentWriter.WriteLine("{");
-                    indentWriter.Indent++;
-
-                    foreach (var privateFieldAssignment in privateFieldAssignments)
-                    {
-                        indentWriter.WriteLine(privateFieldAssignment);
-                    }
-
-                    indentWriter.Indent--;
-                    indentWriter.WriteLine("}");
-                    indentWriter.WriteLine();
+                    indentWriter.WriteLine($"public {async}Task<{_information.DestinationType?.ToDisplayString()}> MapAsync({_information.SourceType?.ToDisplayString()} from) => {callToMapMethod};");
                 }
-
-                var async = _information.IsAsync ? $"async " : $"";
-                var callToMapMethod = _information.IsAsync
-                    ? $"await {fromExpression}.MapTo{_information.DestinationType?.Name}Async({string.Join(", ", mapParameters)})"
-                    : $"Task.FromResult({fromExpression}.MapTo{_information.DestinationType?.Name}({string.Join(", ", mapParameters)}))";
-
-                indentWriter.WriteLine($"public {async}Task<{_information.DestinationType?.ToDisplayString()}> MapAsync({_information.SourceType?.ToDisplayString()} from) => {callToMapMethod};");
-
-                indentWriter.Indent--;
-                indentWriter.WriteLine("}");
             }
         }
 
         private static void WriteNullCheck(IndentedTextWriter indentWriter, string instanceName, string sourceType, string? destinationType)
         {
             indentWriter.WriteLine($"if ({instanceName} is null)");
-            indentWriter.WriteLine("{");
-            indentWriter.Indent++;
-            indentWriter.WriteLine($@"throw new ArgumentNullException(nameof(self), ""{sourceType} -> {destinationType}: Source is null."");");
-            indentWriter.Indent--;
-            indentWriter.WriteLine("}");
+            using (indentWriter.Braces())
+            {
+                indentWriter.WriteLine($@"throw new ArgumentNullException(nameof(self), ""{sourceType} -> {destinationType}: Source is null."");");
+            }
             indentWriter.WriteLine();
         }
     }

--- a/src/GeneratedMapper/Extensions/IndentWriterExtensions.cs
+++ b/src/GeneratedMapper/Extensions/IndentWriterExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.CodeDom.Compiler;
 
-namespace GeneratedMapper.Helpers
+namespace GeneratedMapper.Extensions
 {
     public static class IndentWriterExtensions
     {

--- a/src/GeneratedMapper/Helpers/IndentWriterExtensions.cs
+++ b/src/GeneratedMapper/Helpers/IndentWriterExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.CodeDom.Compiler;
+
+namespace GeneratedMapper.Helpers
+{
+    public static class IndentWriterExtensions
+    {
+        public static IDisposable NoIndent(this IndentedTextWriter indentWriter) => new IndentNothing();
+        public static IDisposable Indent(this IndentedTextWriter indentWriter) => new IndentDisposable(indentWriter);
+        public static IDisposable Braces(this IndentedTextWriter indentWriter) => new IndentDisposable(indentWriter, "{", "}");
+        public static IDisposable ClassSetters(this IndentedTextWriter indentWriter) => new IndentDisposable(indentWriter, "{", "};");
+        private class IndentDisposable : IDisposable
+        {
+            private readonly IndentedTextWriter _indentWriter;
+            private readonly string _after;
+
+            public IndentDisposable(IndentedTextWriter indentWriter, string before = null, string after = null)
+            {
+                _indentWriter = indentWriter;
+                _after = after;
+                if(before != null)
+                {
+                    _indentWriter.WriteLine(before);
+                }
+                _indentWriter.Indent++;
+            }
+
+            public void Dispose()
+            {
+                _indentWriter.Indent--;
+                if(_after != null)
+                {
+                    _indentWriter.WriteLine(_after);
+                }
+            }
+        }
+
+        private class IndentNothing : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Moves Index++ and Index-- to Disposable pattern, so that when in using statements the index is incremented by one.
This way code generated that should be indented higher will be indexed higher in the CodeGenerator class so it's easier to what section of code generation is being worked on.

WriteOpenNamespaceAndStaticClass is a bit weird compared, since there's a possible no indenting option that doesn't do anything, vs everything else where it should be self explanatory.

P.S.
I'm learning code gen and this is a nice real world example to see how it works as a complete package.  Analyzer compile time exceptions as well.