### PR TITLE
Refactor AfterMap from a Configuration setting to dynamically linking to code meeting criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ or configure what exceptions should be thrown when the mapper encounters null.
 - `NamespacesToInclude`: Configures extra namespaces to include in mappers when they prove to be too hard to be recognized by the mapper.
 - `GenerateEnumerableMethods`: Configures if for every X.MapToY() also a IEnumerable<X>.MapToYs() must be generated.
 - `GenerateExpressions`: Configures if for every mapper, the mapping should also be available as `Expression<Func<X, Y>>` for use in APIs which require expressions (like EF or Mongo).
-- `GenerateAfterMapPartial`: Configures a partial method to further configure the mapping.
 - `GenerateInjectableMappers`: Generates a `IMapper<From, To>` for each extension method, which can be added to the DI container using `services.AddMappers()`.
 
 ## More information

--- a/src/Example/Program.cs
+++ b/src/Example/Program.cs
@@ -65,7 +65,7 @@ namespace Example
             var options = new JsonSerializerOptions { WriteIndented = true };
 
             Console.WriteLine(JsonSerializer.Serialize(source.MapToSimpleDestination(), options));
-            Console.WriteLine(JsonSerializer.Serialize(source.MapToComplexDestination(7, new[] { 1.2, 1.3 }, CultureInfo.CurrentCulture), options));
+            Console.WriteLine(JsonSerializer.Serialize(source.MapToComplexDestination(7, new[] { 1.2, 1.3 }, CultureInfo.CurrentCulture, "-Postfix"), options));
 
             var record = new TestRecord("Test");
 

--- a/src/Example/Program.cs
+++ b/src/Example/Program.cs
@@ -10,9 +10,7 @@ using Example.Sources;
     ThrowWhenNotNullableElementIsNull = true,
     ThrowWhenNotNullablePropertyIsNull = true,
     GenerateEnumerableMethods = true,
-    GenerateExpressions = true,
-    // see SourceMapToExtensions how to use partial method
-    GenerateAfterMapPartial = true)]
+    GenerateExpressions = true)]
 namespace Example
 {
     public class Program

--- a/src/Example/SourceMapToExtensions.cs
+++ b/src/Example/SourceMapToExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Example.Sources
+﻿using System.Globalization;
+
+namespace Example.Sources
 {
     public static partial class SourceMapToExtensions
     {
@@ -7,6 +9,10 @@
             target.CompanyName = $"Super custom: {source.Company.Name}";
         }
 
+        static void ComplexAfterMap(Example.Sources.Source source, Example.Destinations.ComplexDestination target, string postFix, CultureInfo? dateResolverCultureInfo)
+        {
+            target.Company.Name = $"Culture {dateResolverCultureInfo.Name}: {source.Company.Name}{postFix}";
+        }
     }
     public static class Extensions
     {

--- a/src/Example/SourceMapToExtensions.cs
+++ b/src/Example/SourceMapToExtensions.cs
@@ -2,9 +2,18 @@
 {
     public static partial class SourceMapToExtensions
     {
-        static partial void AfterMapToSimpleDestination(Example.Sources.Source source, Example.Destinations.SimpleDestination target)
+        static void AfterMap(Example.Sources.Source source, Example.Destinations.SimpleDestination target)
         {
             target.CompanyName = $"Super custom: {source.Company.Name}";
         }
+
+    }
+    public static class Extensions
+    {
+        public static void PublicAfterMapOutsidePartialClass(Example.Sources.Source source, Example.Destinations.SimpleDestination target)
+        {
+            target.CompanyName += " Mapped Outside AfterMap Call";
+        }
+
     }
 }

--- a/src/GeneratedMapper.Tests/AsyncDeepMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/AsyncDeepMappingGeneratorTests.cs
@@ -13,7 +13,7 @@ using System.Globalization;
 using System.Threading.Tasks;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace R {
     public class Resolver { 
         private readonly CultureInfo _cultureInfo;

--- a/src/GeneratedMapper.Tests/AsyncMappingConfigurationTests.cs
+++ b/src/GeneratedMapper.Tests/AsyncMappingConfigurationTests.cs
@@ -12,10 +12,15 @@ namespace GeneratedMapper.Tests
 using System.Threading.Tasks;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = true, GenerateAfterMapPartial = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapAsyncWith(""Name"", typeof(R.AsyncResolver))] public string Name { get; set; } }
+
+    public static partial class AMapToExtensions
+    {
+        static void AfterMapToBAsync(A source, B.B destination) {}
+    }
 }
 
 namespace R {
@@ -51,12 +56,10 @@ namespace A
                 Name = await asyncResolver.ResolveAsync((self.Name ?? throw new GeneratedMapper.Exceptions.PropertyNullException(""A.A -> B.B: Property Name is null.""))),
             };
             
-            AfterMapToBAsync(self, asyncResolverStartIndex, target);
+            AfterMapToBAsync(self, target);
             
             return target;
         }
-        
-        static partial void AfterMapToBAsync(A.A source, int asyncResolverStartIndex, B.B target);
         
         public static async IAsyncEnumerable<B.B> MapToBAsync(this IEnumerable<A.A> self, int asyncResolverStartIndex)
         {
@@ -82,7 +85,7 @@ namespace A
 using System.Threading.Tasks;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapAsyncWith(""Name"", typeof(R.AsyncResolver))] public string Name { get; set; } }

--- a/src/GeneratedMapper.Tests/AsyncMappingEnumerableTests.cs
+++ b/src/GeneratedMapper.Tests/AsyncMappingEnumerableTests.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapAsyncWith(""Names"", typeof(R.AsyncResolver))] public IEnumerable<string> Names { get; set; } }
@@ -67,7 +67,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapAsyncWith(""Names"", typeof(R.AsyncResolver), MapCompleteCollection = true)] public IEnumerable<string> Names { get; set; } }

--- a/src/GeneratedMapper.Tests/AsyncMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/AsyncMappingGeneratorTests.cs
@@ -12,7 +12,7 @@ namespace GeneratedMapper.Tests
 using System.Threading.Tasks;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapAsyncWith(""Name"", typeof(R.AsyncResolver))] public string Name { get; set; } }
@@ -61,7 +61,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapAsyncWith(""Name"", ""ToStringAsync"")] public string Name { get; set; } }
@@ -105,7 +105,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapAsyncWith(""Name"", ""ToStringAsync"")] public string Name { get; set; } public A Parent { get; set; } }
@@ -150,7 +150,7 @@ namespace A
 using System.Threading.Tasks;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapAsyncWith(""Name"", ""ExtensionAsync"")] public string Name { get; set; } }

--- a/src/GeneratedMapper.Tests/AsyncMappingNullabilityTests.cs
+++ b/src/GeneratedMapper.Tests/AsyncMappingNullabilityTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -56,7 +56,7 @@ namespace A
             GeneratorTestHelper.TestReportedDiagnostics(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -75,7 +75,7 @@ namespace B {
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -120,7 +120,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -165,7 +165,7 @@ namespace A
             GeneratorTestHelper.TestReportedDiagnostics(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -184,7 +184,7 @@ namespace B {
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 

--- a/src/GeneratedMapper.Tests/BasicExtensionMethodMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/BasicExtensionMethodMappingGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace Ex {
     public static class StringExtensions { public static string ExtensionMethod(this string subject) { } }
 }
@@ -62,7 +62,7 @@ namespace A
             GeneratorTestHelper.TestReportedDiagnostics(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace Ex {
     public static class StringExtensions { public static string ExtensionMethod(this string subject) { } }
 }
@@ -87,7 +87,7 @@ namespace B {
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace Ex {
     public static class StringExtensions { public static string ExtensionMethod(this string subject) { } }
 }
@@ -140,7 +140,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace Ex {
     public static class StringExtensions { public static string ExtensionMethod(this string subject) { } }
 }

--- a/src/GeneratedMapper.Tests/BasicMapperMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/BasicMapperMappingGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -56,7 +56,7 @@ namespace A
             GeneratorTestHelper.TestReportedDiagnostics(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -76,7 +76,7 @@ namespace B {
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -121,7 +121,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 

--- a/src/GeneratedMapper.Tests/BasicMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/BasicMappingGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string Name { get; set; } }
@@ -52,7 +52,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string Name { get; private set; } }
@@ -93,7 +93,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     public class A { public string Name { get; private set; } }
 }

--- a/src/GeneratedMapper.Tests/BasicMappingIgnoreGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/BasicMappingIgnoreGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string Name { get; set; } [Ignore]public string Title { get; set; } }
@@ -52,7 +52,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     [IgnoreInTarget(""Title"")]
@@ -94,7 +94,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     public class A { public string Name { get; set; } public string Title { get; set; } }
 }
@@ -136,7 +136,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     public class A { public string Name { get; set; } }
 }

--- a/src/GeneratedMapper.Tests/BasicMappingNullableGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/BasicMappingNullableGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string Prop { get; set; } }
@@ -52,7 +52,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapWith(""Prop"", ""Count"")] public string Prop { get; set; } }
@@ -93,7 +93,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapWith(""Prop"", ""ToString"")] public Guid Prop { get; set; } }
@@ -134,7 +134,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapWith(""Prop"", ""ToString"")] public Guid? Prop { get; set; } }

--- a/src/GeneratedMapper.Tests/BasicMappingRecordsGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/BasicMappingRecordsGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public record A(string Name);

--- a/src/GeneratedMapper.Tests/BasicMethodMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/BasicMethodMappingGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -57,7 +57,7 @@ namespace A
             GeneratorTestHelper.TestReportedDiagnostics(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -78,7 +78,7 @@ namespace B {
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -126,7 +126,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 

--- a/src/GeneratedMapper.Tests/BasicResolverMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/BasicResolverMappingGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace R {
     public class Resolver { public string Resolve(string input) { return input; } }
 }
@@ -85,7 +85,7 @@ namespace B {
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace R {
     public class Resolver { public string Resolve(string input) { return input; } }
 }
@@ -135,7 +135,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace R {
     public class Resolver { public string Resolve(string input) { return input; } }
 }
@@ -185,7 +185,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace R {
     public class Resolver<T> { public T Resolve(T input) { return input; } }
 }
@@ -243,7 +243,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace R {
     public class Resolver<TInput, TOutput> { public TOutput Resolve(TInput input) { return default(TOutput); } }
 }
@@ -301,7 +301,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace R {
     public class Resolver<TInput, TOutput> { public TOutput Resolve(TInput input) { return default(TOutput); } }
 }

--- a/src/GeneratedMapper.Tests/CollectionArrayMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/CollectionArrayMappingGeneratorTests.cs
@@ -13,7 +13,7 @@ namespace GeneratedMapper.Tests
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string[] Prop { get; set; } }
@@ -58,7 +58,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string[] Prop { get; set; } }
@@ -104,7 +104,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string[] Prop { get; set; } }
@@ -149,7 +149,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string[] Prop { get; set; } }

--- a/src/GeneratedMapper.Tests/CollectionEnumerableMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/CollectionEnumerableMappingGeneratorTests.cs
@@ -12,7 +12,7 @@ namespace GeneratedMapper.Tests
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public IEnumerable<string> Prop { get; set; } }
@@ -57,7 +57,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public IEnumerable<string> Prop { get; set; } }
@@ -103,7 +103,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public IEnumerable<string> Prop { get; set; } }
@@ -148,7 +148,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public IEnumerable<string> Prop { get; set; } }

--- a/src/GeneratedMapper.Tests/CollectionExtensionMethodGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/CollectionExtensionMethodGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace Ex {
     public static class StringExtensions { public static string ExtensionMethod(this string subject) { } }
 }
@@ -63,7 +63,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace Ex {
     public static class StringExtensions { public static int ExtensionMethod(this string subject, int startIndex) { } }
 }
@@ -115,7 +115,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace Ex {
     public static class StringExtensions { public static int ExtensionMethod(this string subject, int startIndex) { } }
 }

--- a/src/GeneratedMapper.Tests/CollectionListMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/CollectionListMappingGeneratorTests.cs
@@ -12,7 +12,7 @@ namespace GeneratedMapper.Tests
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public List<string> Prop { get; set; } }
@@ -57,7 +57,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public List<string> Prop { get; set; } }
@@ -103,7 +103,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public List<string> Prop { get; set; } }
@@ -148,7 +148,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public List<string> Prop { get; set; } }

--- a/src/GeneratedMapper.Tests/CollectionMapperGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/CollectionMapperGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -90,7 +90,7 @@ namespace C
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 

--- a/src/GeneratedMapper.Tests/CollectionMapperNullableElementsGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/CollectionMapperNullableElementsGeneratorTests.cs
@@ -12,7 +12,7 @@ namespace GeneratedMapper.Tests
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -59,7 +59,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -106,7 +106,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 

--- a/src/GeneratedMapper.Tests/CollectionMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/CollectionMappingGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string[] Prop { get; set; } }
@@ -55,7 +55,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string[]? Prop { get; set; } }
@@ -100,7 +100,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string[] Prop { get; set; } }
@@ -144,7 +144,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string[]? Prop { get; set; } }

--- a/src/GeneratedMapper.Tests/CollectionMethodGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/CollectionMethodGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -58,7 +58,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 

--- a/src/GeneratedMapper.Tests/CollectionResolverGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/CollectionResolverGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace R {
     public class Resolver { public string Resolve(string input) { return input; } }
 }
@@ -64,7 +64,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace R {
     public class Resolver { public Resolver(int id) { } public string Resolve(string input) { return input; } }
 }

--- a/src/GeneratedMapper.Tests/CompilerTests/AfterMap/Destination.cs
+++ b/src/GeneratedMapper.Tests/CompilerTests/AfterMap/Destination.cs
@@ -1,0 +1,8 @@
+﻿namespace GeneratedMapper.Tests.CompilerTests.AfterMap
+{
+    public class Destination
+    {
+        public string Name { get; set; }
+        public string ResolvedName { get; set; }
+    }
+}

--- a/src/GeneratedMapper.Tests/CompilerTests/AfterMap/Extensions.cs
+++ b/src/GeneratedMapper.Tests/CompilerTests/AfterMap/Extensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace GeneratedMapper.Tests.CompilerTests.AfterMap
+{
+    public static class Extensions
+    {
+        public static List<string> Called { get; } = new List<string>();
+        public static int StartIndex { get; private set; }
+        public static int ResolverId { get; private set; }
+        public static string AddtionalParameter { get; private set; }
+
+        public static void AfterMap(Source source, Destination destination) => Called.Add(nameof(AfterMap));
+        public static void NonMap(Source source, Destination destination) => Called.Add(nameof(NonMap));
+        public static void AfterMapWithSubstringParameter(Source source, Destination destination, int startIndex) => StartIndex = startIndex;
+        public static void AfterMapWithResolverParameter(Source source, Destination destination, int resolverId) => ResolverId = resolverId;
+        public static void AfterMapWithAdditionalParameter(Source source, Destination destination, string param) => AddtionalParameter = param;
+    }
+}

--- a/src/GeneratedMapper.Tests/CompilerTests/AfterMap/Resolver.cs
+++ b/src/GeneratedMapper.Tests/CompilerTests/AfterMap/Resolver.cs
@@ -1,0 +1,8 @@
+﻿namespace GeneratedMapper.Tests.CompilerTests.AfterMap
+{
+    public class Resolver
+    {
+        public Resolver(int id) { }
+        public string Resolve(string input) { return input + " Resolved"; }
+    }
+}

--- a/src/GeneratedMapper.Tests/CompilerTests/AfterMap/Source.cs
+++ b/src/GeneratedMapper.Tests/CompilerTests/AfterMap/Source.cs
@@ -1,0 +1,14 @@
+﻿using GeneratedMapper.Attributes;
+
+namespace GeneratedMapper.Tests.CompilerTests.AfterMap
+{
+    [MapTo(typeof(Destination))]
+    public class Source
+    {
+        [MapWith("Name", "Substring")]
+        public string Name { get; set; } = "0123456";
+
+        [MapWith("ResolvedName", typeof(Resolver))]
+        public string ResolvedName { get; set; } = "Name";
+    }
+}

--- a/src/GeneratedMapper.Tests/CompilerTests/AfterMap/SourceMapToExtensions.cs
+++ b/src/GeneratedMapper.Tests/CompilerTests/AfterMap/SourceMapToExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace GeneratedMapper.Tests.CompilerTests.AfterMap
+{
+    public static partial class SourceMapToExtensions
+    {
+        public static List<string> Called { get; } = new List<string>();
+        public static int StartIndex { get; private set; }
+        public static int ResolverId { get; private set; }
+        public static string AddtionalParameter { get; private set; }
+
+        static void AfterMap(Source source, Destination destination) => Called.Add(nameof(AfterMap));
+        static void NonMap(Source source, Destination destination) => Called.Add(nameof(NonMap));
+        static void AfterMapWithSubstringParameter(Source source, Destination destination, int startIndex) => StartIndex = startIndex;
+        static void AfterMapWithResolverParameter(Source source, Destination destination, int resolverId) => ResolverId = resolverId;
+        static void AfterMapWithAdditionalParameter(Source source, Destination destination, string param) => AddtionalParameter = param;
+    }
+}

--- a/src/GeneratedMapper.Tests/CompilerTests/AfterMap/Tests.cs
+++ b/src/GeneratedMapper.Tests/CompilerTests/AfterMap/Tests.cs
@@ -1,0 +1,107 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+
+namespace GeneratedMapper.Tests.CompilerTests.AfterMap
+{
+    public class Tests
+    {
+        private const int StartIndex = 4;
+        private const int ResolverId = 45;
+        private const string AddtionalParameter = "Param";
+
+        [Test]
+        public void Extension_Method_Called()
+        {
+            var from = new Source();
+            from.MapToDestination(1, ResolverId, AddtionalParameter).Name.Should().BeEquivalentTo("123456");
+            from.MapToDestination(3, ResolverId, AddtionalParameter).Name.Should().BeEquivalentTo("3456");
+        }
+
+        [Test]
+        public void Resolver_Resolve_Method_Called()
+        {
+            var from = new Source();
+            from.MapToDestination(StartIndex, ResolverId, AddtionalParameter).ResolvedName.Should().BeEquivalentTo("Name Resolved");
+        }
+
+        [Test]
+        public void Partial_Static_Private_AfterMap_Called()
+        {
+            var from = new Source();
+            from.MapToDestination(StartIndex, ResolverId, AddtionalParameter);
+            SourceMapToExtensions.Called.Should().Contain("AfterMap");
+        }
+
+        [Test]
+        public void Partial_Static_Private_Non_AfterMap_Not_Called()
+        {
+            var from = new Source();
+            from.MapToDestination(StartIndex, ResolverId, AddtionalParameter);
+            SourceMapToExtensions.Called.Should().NotContain("NonMap");
+        }
+
+        [Test]
+        public void Partial_Static_Private_AfterMapWithSubstringParameter_Called_With_StartIndex()
+        {
+            var from = new Source();
+            from.MapToDestination(StartIndex, ResolverId, AddtionalParameter);
+            SourceMapToExtensions.StartIndex.Should().Be(StartIndex);
+        }
+
+        [Test]
+        public void Partial_Static_Private_AfterMapWithResolverParameter_Called_With_ResolverId()
+        {
+            var from = new Source();
+            from.MapToDestination(StartIndex, ResolverId, AddtionalParameter);
+            SourceMapToExtensions.ResolverId.Should().Be(ResolverId);
+        }
+
+        [Test]
+        public void Partial_Static_Private_AfterMapWithAdditionalParameter_Called_With_AdditionalParameter()
+        {
+            var from = new Source();
+            from.MapToDestination(StartIndex, ResolverId, AddtionalParameter);
+            SourceMapToExtensions.AddtionalParameter.Should().Be(AddtionalParameter);
+        }
+
+        [Test]
+        public void Static_Public_AfterMap_Called()
+        {
+            var from = new Source();
+            from.MapToDestination(StartIndex, ResolverId, AddtionalParameter);
+            Extensions.Called.Should().Contain("AfterMap");
+        }
+
+        [Test]
+        public void Static_Public_Non_AfterMap_Not_Called()
+        {
+            var from = new Source();
+            from.MapToDestination(StartIndex, ResolverId, AddtionalParameter);
+            Extensions.Called.Should().NotContain("NonMap");
+        }
+
+        [Test]
+        public void Static_Public_AfterMapWithSubstringParameter_Called_With_StartIndex()
+        {
+            var from = new Source();
+            from.MapToDestination(StartIndex, ResolverId, AddtionalParameter);
+            Extensions.StartIndex.Should().Be(StartIndex);
+        }
+
+        [Test]
+        public void Static_Public_AfterMapWithResolverParameter_Called_With_ResolverId()
+        {
+            var from = new Source();
+            from.MapToDestination(StartIndex, ResolverId, AddtionalParameter);
+            Extensions.ResolverId.Should().Be(ResolverId);
+        }
+
+        [Test]
+        public void Static_Public_AfterMapWithAdditionalParameter_Called_With_AdditionalParameter()
+        {
+            var from = new Source();
+            from.MapToDestination(StartIndex, ResolverId, AddtionalParameter);
+            Extensions.AddtionalParameter.Should().Be(AddtionalParameter);
+        }
+    }
+}

--- a/src/GeneratedMapper.Tests/ConfigurationTests.cs
+++ b/src/GeneratedMapper.Tests/ConfigurationTests.cs
@@ -248,7 +248,8 @@ namespace A
 using GeneratedMapper.Attributes;
 
 [assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
-namespace A {
+namespace A
+{
     [MapTo(typeof(B.B))]
     public class A { [MapWith(""Name"", ""Substring"")] public string Name { get; set; } }
 
@@ -260,7 +261,6 @@ namespace A {
 
 namespace B {
     public class B { public string Name { get; set; } }
-}
 }",
 @"using System;
 

--- a/src/GeneratedMapper.Tests/ConfigurationTests.cs
+++ b/src/GeneratedMapper.Tests/ConfigurationTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, NamespacesToInclude = new[] { ""Hard.To.Recognize.Namespace"" })]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, NamespacesToInclude = new[] { ""Hard.To.Recognize.Namespace"" })]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string Name { get; set; } }
@@ -53,7 +53,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullablePropertyIsNull = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullablePropertyIsNull = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string Name { get; set; } }
@@ -95,7 +95,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public List<string> Prop { get; set; } }
@@ -139,7 +139,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, GenerateEnumerableMethods = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateEnumerableMethods = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string Name { get; set; } }
@@ -192,7 +192,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, GenerateEnumerableMethods = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateEnumerableMethods = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapWith(""Name"", ""Substring"")] public string Name { get; set; } }
@@ -247,10 +247,15 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, GenerateAfterMapPartial = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapWith(""Name"", ""Substring"")] public string Name { get; set; } }
+
+    public static partial class AMapToExtensions
+    {
+        static void AfterMapToB(A source, B.B destination) {}
+    }
 }
 
 namespace B {
@@ -277,12 +282,10 @@ namespace A
                 Name = (self.Name ?? throw new GeneratedMapper.Exceptions.PropertyNullException(""A.A -> B.B: Property Name is null."")).Substring(startIndex),
             };
             
-            AfterMapToB(self, startIndex, target);
+            AfterMapToB(self, target);
             
             return target;
         }
-        
-        static partial void AfterMapToB(A.A source, int startIndex, B.B target);
     }
 }
 ");

--- a/src/GeneratedMapper.Tests/DeepMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/DeepMappingGeneratorTests.cs
@@ -13,7 +13,7 @@ namespace GeneratedMapper.Tests
 using System.Globalization;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace R {
     public class Resolver { 
         private readonly CultureInfo _cultureInfo;

--- a/src/GeneratedMapper.Tests/DictionaryMapperGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/DictionaryMapperGeneratorTests.cs
@@ -12,7 +12,7 @@ namespace GeneratedMapper.Tests
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -59,7 +59,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -106,7 +106,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -153,7 +153,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -200,7 +200,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -247,7 +247,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -294,7 +294,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -341,7 +341,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -388,7 +388,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -435,7 +435,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -482,7 +482,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -529,7 +529,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -576,7 +576,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 

--- a/src/GeneratedMapper.Tests/DictionaryMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/DictionaryMappingGeneratorTests.cs
@@ -12,7 +12,7 @@ namespace GeneratedMapper.Tests
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -59,7 +59,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -106,7 +106,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -153,7 +153,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -200,7 +200,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -247,7 +247,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -294,7 +294,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -341,7 +341,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -388,7 +388,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -435,7 +435,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -482,7 +482,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -529,7 +529,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -576,7 +576,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 

--- a/src/GeneratedMapper.Tests/DictionaryMethodGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/DictionaryMethodGeneratorTests.cs
@@ -14,7 +14,7 @@ using GeneratedMapper.Attributes;
 
 using A;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace R {
     public class Resolver { public string Resolve(string input) { return input; } public B.B Resolve(A.A input) { return input.MapToB(); } } }
 }
@@ -66,7 +66,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -117,7 +117,7 @@ using GeneratedMapper.Attributes;
 
 using A;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace R {
     public class Resolver { public Dictionary<string, B> Resolve(Dictionary<string, A> input) { return input.ToDictionary(x => x.Key, x => x.Value.MapToB()); } } }
 }

--- a/src/GeneratedMapper.Tests/DictionaryResolverGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/DictionaryResolverGeneratorTests.cs
@@ -14,7 +14,7 @@ using GeneratedMapper.Attributes;
 
 using A;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace R {
     public class Resolver { public string Resolve(string input) { return input; } public B.B Resolve(A.A input) { return input.MapToB(); } } }
 }
@@ -68,7 +68,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -121,7 +121,7 @@ using GeneratedMapper.Attributes;
 
 using A;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace R {
     public class Resolver { public Dictionary<string, B> Resolve(Dictionary<string, A> input) { return input.ToDictionary(x => x.Key, x => x.Value.MapToB()); } } }
 }

--- a/src/GeneratedMapper.Tests/ExpressionBasicTests.cs
+++ b/src/GeneratedMapper.Tests/ExpressionBasicTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string Name { get; set; } }
@@ -67,7 +67,7 @@ namespace A.Expressions
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapWith(typeof(R.Resolver))] public int Name { get; set; } }
@@ -128,7 +128,7 @@ namespace A.Expressions
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string Name { get; set; } public A Sub { get; set; } }
@@ -201,7 +201,7 @@ namespace A.Expressions
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B1))]
     public class A1 { public string Name { get; set; } public A2 Sub { get; set; } }
@@ -337,7 +337,7 @@ namespace A.Expressions
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B), MaxRecursion = 5)]
     public class A { public string Name { get; set; } public A Sub { get; set; } }

--- a/src/GeneratedMapper.Tests/ExpressionDictionaryTests.cs
+++ b/src/GeneratedMapper.Tests/ExpressionDictionaryTests.cs
@@ -12,7 +12,7 @@ namespace GeneratedMapper.Tests
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string? Name { get; set; } public Dictionary<string, string>? Subs { get; set; } }
@@ -76,7 +76,7 @@ namespace A.Expressions
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string? Name { get; set; } public Dictionary<string, A>? Subs { get; set; } }
@@ -151,7 +151,7 @@ namespace A.Expressions
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string? Name { get; set; } public Dictionary<A, A>? Subs { get; set; } }

--- a/src/GeneratedMapper.Tests/ExpressionEnumerableTests.cs
+++ b/src/GeneratedMapper.Tests/ExpressionEnumerableTests.cs
@@ -12,7 +12,7 @@ namespace GeneratedMapper.Tests
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string? Name { get; set; } public IEnumerable<string>? Subs { get; set; } }
@@ -76,7 +76,7 @@ namespace A.Expressions
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string? Name { get; set; } public IEnumerable<A>? Subs { get; set; } }
@@ -151,7 +151,7 @@ namespace A.Expressions
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string? Name { get; set; } public List<A>? Subs { get; set; } }
@@ -226,7 +226,7 @@ namespace A.Expressions
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string? Name { get; set; } public List<string>? Subs { get; set; } }
@@ -290,7 +290,7 @@ namespace A.Expressions
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapWith(""Name"", ""Substring"")] public string? Name { get; set; } public A[]? Subs { get; set; } }

--- a/src/GeneratedMapper.Tests/ExpressionMethodTests.cs
+++ b/src/GeneratedMapper.Tests/ExpressionMethodTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapWith(""Name"", ""ToString"")] public int Name { get; set; } }
@@ -67,7 +67,7 @@ namespace A.Expressions
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapWith(""Name"", ""ToString"")] public int? Name { get; set; } }
@@ -127,7 +127,7 @@ namespace A.Expressions
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapWith(""Name"", ""ToString"")] public int Name { get; set; } }
@@ -183,7 +183,7 @@ namespace A.Expressions
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapWith(""Name"", ""Substring"")] public string Name { get; set; } }

--- a/src/GeneratedMapper.Tests/ExpressionNullableElementsEnumerableTests.cs
+++ b/src/GeneratedMapper.Tests/ExpressionNullableElementsEnumerableTests.cs
@@ -12,7 +12,7 @@ namespace GeneratedMapper.Tests
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string? Name { get; set; } public List<string?>? Subs { get; set; } }
@@ -76,7 +76,7 @@ namespace A.Expressions
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string? Name { get; set; } public List<string>? Subs { get; set; } }
@@ -140,7 +140,7 @@ namespace A.Expressions
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string? Name { get; set; } public List<string?>? Subs { get; set; } }
@@ -204,7 +204,7 @@ namespace A.Expressions
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B), MaxRecursion = 1)]
     public class A { public string? Name { get; set; } public List<A?>? Subs { get; set; } }
@@ -271,7 +271,7 @@ namespace A.Expressions
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B), MaxRecursion = 1)]
     public class A { public string? Name { get; set; } public List<A>? Subs { get; set; } }
@@ -338,7 +338,7 @@ namespace A.Expressions
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B), MaxRecursion = 1)]
     public class A { public string? Name { get; set; } public List<A?>? Subs { get; set; } }
@@ -405,7 +405,7 @@ namespace A.Expressions
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B), MaxRecursion = 1)]
     public class A { public string? Name { get; set; } public Dictionary<A?, A>? Subs { get; set; } }

--- a/src/GeneratedMapper.Tests/ExpressionNullableEnumerableTests.cs
+++ b/src/GeneratedMapper.Tests/ExpressionNullableEnumerableTests.cs
@@ -12,7 +12,7 @@ namespace GeneratedMapper.Tests
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string? Name { get; set; } public List<string>? Subs { get; set; } }
@@ -76,7 +76,7 @@ namespace A.Expressions
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string? Name { get; set; } public List<string> Subs { get; set; } }
@@ -140,7 +140,7 @@ namespace A.Expressions
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, ThrowWhenNotNullableElementIsNull = false, ThrowWhenNotNullablePropertyIsNull = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string? Name { get; set; } public Dictionary<string?, string?>? Subs { get; set; } }

--- a/src/GeneratedMapper.Tests/GeneratedMapper.Tests.csproj
+++ b/src/GeneratedMapper.Tests/GeneratedMapper.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
@@ -19,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\GeneratedMapper\GeneratedMapper.csproj" />
+    <ProjectReference Include="..\GeneratedMapper\GeneratedMapper.csproj" OutputItemType="Analyzer" />
   </ItemGroup>
 
 </Project>

--- a/src/GeneratedMapper.Tests/Helpers/GeneratorTestHelper.cs
+++ b/src/GeneratedMapper.Tests/Helpers/GeneratorTestHelper.cs
@@ -13,8 +13,8 @@ namespace GeneratedMapper.Tests.Helpers
         {
             var syntaxTree = CSharpSyntaxTree.ParseText(source);
             var references = AppDomain.CurrentDomain.GetAssemblies()
-                .Where(_ => !_.IsDynamic && !string.IsNullOrWhiteSpace(_.Location))
-                .Select(_ => MetadataReference.CreateFromFile(_.Location))
+                .Where(x => !x.IsDynamic && !string.IsNullOrWhiteSpace(x.Location))
+                .Select(x => MetadataReference.CreateFromFile(x.Location))
                 .Concat(new[] { MetadataReference.CreateFromFile(typeof(MapperGenerator).Assembly.Location) });
             var compilation = CSharpCompilation.Create("generator", new SyntaxTree[] { syntaxTree },
                 references, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));

--- a/src/GeneratedMapper.Tests/InheritanceMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/InheritanceMappingGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A : AA { public string Name1 { get; set; } }
@@ -62,7 +62,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     [IgnoreInTarget(nameof(B.BB.Name2))]

--- a/src/GeneratedMapper.Tests/InheritanceOverrideMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/InheritanceOverrideMappingGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A : AA { public override string Name { get; set; } }
@@ -60,7 +60,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A : AA { public override string Name { get; set; } }

--- a/src/GeneratedMapper.Tests/InjectableMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/InjectableMappingGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, GenerateInjectableMappers = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateInjectableMappers = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { public string Name { get; set; } }
@@ -74,7 +74,7 @@ namespace Microsoft.Extensions.DependencyInjection
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, GenerateInjectableMappers = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateInjectableMappers = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapAsyncWith(""Name"", ""ToStringAsync"")] public string Name { get; set; } }
@@ -139,7 +139,7 @@ namespace Microsoft.Extensions.DependencyInjection
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, GenerateInjectableMappers = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateInjectableMappers = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { [MapWith(""Name"", typeof(R.Resolver))] public string Name { get; set; } }

--- a/src/GeneratedMapper.Tests/NestedMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/NestedMappingGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     public class A { public AA Sub { get; set; } public class AA { public string Name { get; set; } } }
 }
@@ -52,7 +52,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     public class A { public AA Sub1 { get; set; } public class AA { public AAA Sub2 { get; set; } public class AAA { public AAAA Sub3 { get; set; } public class AAAA { public string Name { get; set; } } } } }
 }
@@ -93,7 +93,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     public class A { public AA Sub { get; set; } public class AA { public string Name { get; set; } } }
 }
@@ -134,7 +134,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     public class A { public AA Sub1 { get; set; } public class AA { public AAA Sub2 { get; set; } public class AAA { public AAAA Sub3 { get; set; } public class AAAA { public string Name { get; set; } } } } }
 }
@@ -175,7 +175,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     public class A { public AA Sub { get; set; } public class AA { public int Count { get; set; } } }
 }
@@ -216,7 +216,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     public class A { public AA Sub1 { get; set; } public class AA { public AAA Sub2 { get; set; } public class AAA { public AAAA Sub3 { get; set; } public class AAAA { public int Count { get; set; } } } } }
 }
@@ -257,7 +257,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     public class A { public AA Sub { get; set; } public class AA { public int Count { get; set; } } }
 }

--- a/src/GeneratedMapper.Tests/NullabilityOverrideTests.cs
+++ b/src/GeneratedMapper.Tests/NullabilityOverrideTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B)]
     public class A { [MapWith(""Name"", ""ToString"", IgnoreNullIncompatibility = true)] public string? Name { get; set; } }

--- a/src/GeneratedMapper.Tests/ParametersFromExtensionMethodMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/ParametersFromExtensionMethodMappingGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace Ex {
     public static class StringExtensions { public static string ExtensionMethod(this string subject, int startIndex) { } }
 }
@@ -62,7 +62,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace Ex {
     public static class StringExtensions { public static string ExtensionMethod(this string subject, int startIndex) { } }
 }
@@ -118,7 +118,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace Ex1 {
     public static class StringExtensions1 { 
         public static string ExtensionMethod1(this string subject, int startIndex) { } 

--- a/src/GeneratedMapper.Tests/ParametersFromMapperMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/ParametersFromMapperMappingGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -60,7 +60,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -112,7 +112,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 

--- a/src/GeneratedMapper.Tests/ParametersFromMethodMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/ParametersFromMethodMappingGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -57,7 +57,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -108,7 +108,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 

--- a/src/GeneratedMapper.Tests/ParametersFromResolverMappingGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/ParametersFromResolverMappingGeneratorTests.cs
@@ -11,7 +11,7 @@ namespace GeneratedMapper.Tests
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace R {
     public class Resolver { public Resolver(string arg1, string arg2) { } public string Resolve(string input) { return input; } }
 }
@@ -60,7 +60,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace R {
     public class Resolver { public Resolver(string arg1, string arg2) { } public string Resolve(string input) { return input; } }
 }
@@ -112,7 +112,7 @@ namespace A
             GeneratorTestHelper.TestGeneratedCode(@"using System;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace R {
     public class Resolver1 { public Resolver1(string arg1, string arg2) { } public string Resolve(string input) { return input; } }
     public class Resolver2 { public Resolver2(string arg1, string? arg2 = ""default string"") { } public string Resolve(string input) { return input; } }

--- a/src/GeneratedMapper.Tests/TupleMapperGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/TupleMapperGeneratorTests.cs
@@ -12,7 +12,7 @@ namespace GeneratedMapper.Tests
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -57,7 +57,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 
@@ -102,7 +102,7 @@ namespace A
 using System.Collections.Generic;
 using GeneratedMapper.Attributes;
 
-[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateAfterMapPartial = false, GenerateExpressions = true)]
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = false, GenerateExpressions = true)]
 namespace A {
     [MapTo(typeof(B.B))]
     public class A { 

--- a/src/GeneratedMapper/Attributes/MapperGeneratorConfigurationAttribute.cs
+++ b/src/GeneratedMapper/Attributes/MapperGeneratorConfigurationAttribute.cs
@@ -49,12 +49,7 @@ namespace GeneratedMapper.Attributes
         /// Only mappers which do not rely on any resolver or mapper will be created as expression.
         /// </summary>
         public bool GenerateExpressions { get; set; }
-
-        /// <summary>
-        /// Instruct the mapper to also create the AfterMap method in each mapping.
-        /// </summary>
-        public bool GenerateAfterMapPartial { get; set; } = true;
-
+        
         /// <summary>
         /// Instruct the code generator to also generate IMapper&lt;TFrom, TTo&gt; for each of the mappings. 
         /// </summary>

--- a/src/GeneratedMapper/Builders/Base/BuilderBase.cs
+++ b/src/GeneratedMapper/Builders/Base/BuilderBase.cs
@@ -2,6 +2,7 @@
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Linq;
+using GeneratedMapper.Helpers;
 using GeneratedMapper.Information;
 
 namespace GeneratedMapper.Builders.Base
@@ -64,33 +65,15 @@ namespace GeneratedMapper.Builders.Base
                 indentWriter.WriteLine();
             }
         }
-        protected void WriteOpenNamespaceAndStaticClass(IndentedTextWriter indentWriter, string extraNamespaceName, string className)
+        protected IDisposable WriteOpenNamespaceAndStaticClass(IndentedTextWriter indentWriter, string extraNamespaceName)
         {
             if (_information.SourceType != null && !_information.SourceType.ContainingNamespace.IsGlobalNamespace)
             {
                 indentWriter.WriteLine($"namespace {_information.SourceType.ContainingNamespace.ToDisplayString()}{extraNamespaceName}");
-                indentWriter.WriteLine("{");
-                indentWriter.Indent++;
+                return indentWriter.Braces();
             }
 
-            indentWriter.WriteLine($"public static partial class {className}");
-            indentWriter.WriteLine("{");
-            indentWriter.Indent++;
-        }
-
-        protected static void WriteCloseStaticClass(IndentedTextWriter indentWriter)
-        {
-            indentWriter.Indent--;
-            indentWriter.WriteLine("}");
-        }
-
-        protected void WriteCloseNamespace(IndentedTextWriter indentWriter)
-        {
-            if (_information.SourceType != null && !_information.SourceType.ContainingNamespace.IsGlobalNamespace)
-            {
-                indentWriter.Indent--;
-                indentWriter.WriteLine("}");
-            }
+            return indentWriter.NoIndent();
         }
 
         protected IEnumerable<string> GenerateCode<T>(IEnumerable<T> builders, Func<T, string?> mappingFeature)

--- a/src/GeneratedMapper/Builders/Base/BuilderBase.cs
+++ b/src/GeneratedMapper/Builders/Base/BuilderBase.cs
@@ -2,7 +2,7 @@
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Linq;
-using GeneratedMapper.Helpers;
+using GeneratedMapper.Extensions;
 using GeneratedMapper.Information;
 
 namespace GeneratedMapper.Builders.Base
@@ -65,7 +65,7 @@ namespace GeneratedMapper.Builders.Base
                 indentWriter.WriteLine();
             }
         }
-        protected IDisposable WriteOpenNamespaceAndStaticClass(IndentedTextWriter indentWriter, string extraNamespaceName)
+        protected IDisposable WriteOpenNamespace(IndentedTextWriter indentWriter, string extraNamespaceName)
         {
             if (_information.SourceType != null && !_information.SourceType.ContainingNamespace.IsGlobalNamespace)
             {

--- a/src/GeneratedMapper/Builders/ExpressionBuilder.cs
+++ b/src/GeneratedMapper/Builders/ExpressionBuilder.cs
@@ -5,7 +5,6 @@ using System.Text;
 using GeneratedMapper.Builders.Base;
 using GeneratedMapper.Enums;
 using GeneratedMapper.Extensions;
-using GeneratedMapper.Helpers;
 using GeneratedMapper.Information;
 using Microsoft.CodeAnalysis.Text;
 
@@ -32,7 +31,7 @@ namespace GeneratedMapper.Builders
                     .SelectMany(x => x.NamespacesUsed)),
                 allowNamespacesForAsync: false);
             WriteOptionalNullableEnablePragma(indentWriter);
-            using(WriteOpenNamespaceAndStaticClass(indentWriter, ".Expressions"))
+            using(WriteOpenNamespace(indentWriter, ".Expressions"))
             {
                 indentWriter.WriteLine($"public static partial class {_information.SourceType?.Name ?? ""}");
                 using (indentWriter.Braces())

--- a/src/GeneratedMapper/Builders/ExpressionBuilder.cs
+++ b/src/GeneratedMapper/Builders/ExpressionBuilder.cs
@@ -5,6 +5,7 @@ using System.Text;
 using GeneratedMapper.Builders.Base;
 using GeneratedMapper.Enums;
 using GeneratedMapper.Extensions;
+using GeneratedMapper.Helpers;
 using GeneratedMapper.Information;
 using Microsoft.CodeAnalysis.Text;
 
@@ -31,12 +32,14 @@ namespace GeneratedMapper.Builders
                     .SelectMany(x => x.NamespacesUsed)),
                 allowNamespacesForAsync: false);
             WriteOptionalNullableEnablePragma(indentWriter);
-            WriteOpenNamespaceAndStaticClass(indentWriter, ".Expressions", _information.SourceType?.Name ?? "");
-
-            WriteMethod(indentWriter);
-
-            WriteCloseStaticClass(indentWriter);
-            WriteCloseNamespace(indentWriter);
+            using(WriteOpenNamespaceAndStaticClass(indentWriter, ".Expressions"))
+            {
+                indentWriter.WriteLine($"public static partial class {_information.SourceType?.Name ?? ""}");
+                using (indentWriter.Braces())
+                {
+                    WriteMethod(indentWriter);
+                }
+            }
 
             return SourceText.From(writer.ToString(), Encoding.UTF8);
         }
@@ -46,13 +49,13 @@ namespace GeneratedMapper.Builders
             var mapParameters = _information.Mappings.Where(x => !x.IsAsync).SelectMany(x => x.MapParametersRequired.Select(x => x.ToMethodParameter(string.Empty))).Distinct();
 
             indentWriter.WriteLine($"public static Expression<Func<{_information.SourceType?.ToDisplayString()}, {_information.DestinationType?.ToDisplayString()}>> To{_information.DestinationType?.Name}({string.Join(", ", mapParameters)}) => ({_information.SourceType?.ToDisplayString()} {SourceInstanceName}) =>");
-            indentWriter.Indent++;
+            using (indentWriter.Indent())
+            {
+                var classBuilder = new ClassExpressionBuilder(new ExpressionContext<MappingInformation>(_information, SourceInstanceName, _maxRecursion));
 
-            var classBuilder = new ClassExpressionBuilder(new ExpressionContext<MappingInformation>(_information, SourceInstanceName, _maxRecursion));
-
-            classBuilder.WriteClass(indentWriter);
-            indentWriter.WriteLine(";");
-            indentWriter.Indent--;
+                classBuilder.WriteClass(indentWriter);
+                indentWriter.WriteLine(";");
+            }
         }
     }
 }

--- a/src/GeneratedMapper/Builders/InjectableMapperServiceCollectionRegistrationBuilder.cs
+++ b/src/GeneratedMapper/Builders/InjectableMapperServiceCollectionRegistrationBuilder.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using GeneratedMapper.Enums;
+using GeneratedMapper.Helpers;
 using GeneratedMapper.Information;
 using Microsoft.CodeAnalysis.Text;
 
@@ -29,43 +30,32 @@ namespace GeneratedMapper.Builders
             indentWriter.WriteLine("using System;");
             indentWriter.WriteLine();
             indentWriter.WriteLine("namespace Microsoft.Extensions.DependencyInjection");
-            indentWriter.WriteLine("{");
-            indentWriter.Indent++;
-
-            indentWriter.WriteLine("public static class GeneratedMapperExtensions");
-
-            indentWriter.WriteLine("{");
-            indentWriter.Indent++;
-
-            indentWriter.WriteLine("public static IServiceCollection AddMappers(this IServiceCollection services)");
-
-            indentWriter.WriteLine("{");
-            indentWriter.Indent++;
-
-            foreach (var mappingInformation in _injectables)
+            using (indentWriter.Braces())
             {
-                var className = $"{mappingInformation.SourceType?.Name}MapTo{mappingInformation.DestinationType?.Name}";
+                indentWriter.WriteLine("public static class GeneratedMapperExtensions");
+                using (indentWriter.Braces())
+                {
+                    indentWriter.WriteLine("public static IServiceCollection AddMappers(this IServiceCollection services)");
+                    using (indentWriter.Braces())
+                    {
+                        foreach (var mappingInformation in _injectables)
+                        {
+                            var className = $"{mappingInformation.SourceType?.Name}MapTo{mappingInformation.DestinationType?.Name}";
 
-                var fullClassName = (mappingInformation.SourceType?.ContainingNamespace.IsGlobalNamespace != true)
-                    ? $"{mappingInformation.SourceType?.ContainingNamespace.ToDisplayString()}.{className}"
-                    : className;
+                            var fullClassName = (mappingInformation.SourceType?.ContainingNamespace.IsGlobalNamespace != true)
+                                ? $"{mappingInformation.SourceType?.ContainingNamespace.ToDisplayString()}.{className}"
+                                : className;
 
-                var interfaceName = $"IMapper<{mappingInformation.SourceType?.ToDisplayString()}, {mappingInformation.DestinationType?.ToDisplayString()}>";
+                            var interfaceName = $"IMapper<{mappingInformation.SourceType?.ToDisplayString()}, {mappingInformation.DestinationType?.ToDisplayString()}>";
 
-                indentWriter.WriteLine($"services.AddTransient<{interfaceName}, {fullClassName}>();");
+                            indentWriter.WriteLine($"services.AddTransient<{interfaceName}, {fullClassName}>();");
+                        }
+
+                        indentWriter.WriteLine();
+                        indentWriter.WriteLine("return services;");
+                    }
+                }
             }
-
-            indentWriter.WriteLine();
-            indentWriter.WriteLine("return services;");
-
-            indentWriter.Indent--;
-            indentWriter.WriteLine("}");
-
-            indentWriter.Indent--;
-            indentWriter.WriteLine("}");
-
-            indentWriter.Indent--;
-            indentWriter.WriteLine("}");
 
             return SourceText.From(writer.ToString(), Encoding.UTF8);
         }

--- a/src/GeneratedMapper/Builders/InjectableMapperServiceCollectionRegistrationBuilder.cs
+++ b/src/GeneratedMapper/Builders/InjectableMapperServiceCollectionRegistrationBuilder.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using GeneratedMapper.Enums;
-using GeneratedMapper.Helpers;
+using GeneratedMapper.Extensions;
 using GeneratedMapper.Information;
 using Microsoft.CodeAnalysis.Text;
 

--- a/src/GeneratedMapper/Builders/MappingBuilder.cs
+++ b/src/GeneratedMapper/Builders/MappingBuilder.cs
@@ -69,28 +69,23 @@ namespace GeneratedMapper.Builders
                 }
 
                 indentWriter.WriteLine();
-
-                if (_information.ConfigurationValues.Customizations.GenerateAfterMapPartial)
+                
+                foreach (var afterMap in _information.AfterMaps)
                 {
-                    var partialArguments = new[] { SourceInstanceName }
-                        .Union(_propertyMappingBuilders.SelectMany(x => x.MapArgumentsRequired().Select(x => x.ToArgument(string.Empty))).Distinct())
-                        .Append(TargetInstanceName);
+                    if (afterMap.PartOfType.ContainingNamespace.Equals(_information.SourceType.ContainingNamespace) &&
+                        afterMap.PartOfType.Name == $"{_information.SourceType?.Name}MapToExtensions")
+                    {
+                        indentWriter.WriteLine($"{afterMap.MethodName}({SourceInstanceName}, {TargetInstanceName});");
+                    }
+                    else
+                    {
+                        indentWriter.WriteLine($"{afterMap.PartOfType.ToDisplayString()}.{afterMap.MethodName}({SourceInstanceName}, {TargetInstanceName});");
+                    }
 
-                    indentWriter.WriteLine($"After{extensionMethodName}({string.Join(", ", partialArguments)});");
                     indentWriter.WriteLine();
                 }
 
                 indentWriter.WriteLine($"return {TargetInstanceName};");
-            }
-            
-            if (_information.ConfigurationValues.Customizations.GenerateAfterMapPartial)
-            {
-                var partialParameters = new[] { $"{_information.SourceType?.ToDisplayString()} {PartialSourceInstanceName}" }
-                    .Union(_propertyMappingBuilders.SelectMany(x => x.MapArgumentsRequired().Select(x => x.ToMethodParameter(string.Empty))).Distinct())
-                    .Append($"{_information.DestinationType?.ToDisplayString()} {PartialTargetInstanceName}");
-
-                indentWriter.WriteLine();
-                indentWriter.WriteLine($"static partial void After{extensionMethodName}({string.Join(", ", partialParameters)});");
             }
         }
 

--- a/src/GeneratedMapper/Builders/MappingBuilder.cs
+++ b/src/GeneratedMapper/Builders/MappingBuilder.cs
@@ -6,7 +6,6 @@ using System.Text;
 using GeneratedMapper.Builders.Base;
 using GeneratedMapper.Enums;
 using GeneratedMapper.Extensions;
-using GeneratedMapper.Helpers;
 using GeneratedMapper.Information;
 using Microsoft.CodeAnalysis.Text;
 
@@ -29,7 +28,7 @@ namespace GeneratedMapper.Builders
 
             WriteUsingNamespaces(indentWriter, _propertyMappingBuilders.SelectMany(map => map.NamespacesUsed()));
             WriteOptionalNullableEnablePragma(indentWriter);
-            using (WriteOpenNamespaceAndStaticClass(indentWriter, ""))
+            using (WriteOpenNamespace(indentWriter, ""))
             {
                 indentWriter.WriteLine($"public static partial class {_information.SourceType?.Name}MapToExtensions");
                 using (indentWriter.Braces())

--- a/src/GeneratedMapper/Builders/MappingBuilder.cs
+++ b/src/GeneratedMapper/Builders/MappingBuilder.cs
@@ -6,6 +6,7 @@ using System.Text;
 using GeneratedMapper.Builders.Base;
 using GeneratedMapper.Enums;
 using GeneratedMapper.Extensions;
+using GeneratedMapper.Helpers;
 using GeneratedMapper.Information;
 using Microsoft.CodeAnalysis.Text;
 
@@ -28,17 +29,17 @@ namespace GeneratedMapper.Builders
 
             WriteUsingNamespaces(indentWriter, _propertyMappingBuilders.SelectMany(map => map.NamespacesUsed()));
             WriteOptionalNullableEnablePragma(indentWriter);
-            WriteOpenNamespaceAndStaticClass(indentWriter, "", $"{_information.SourceType?.Name}MapToExtensions");
+            using (WriteOpenNamespaceAndStaticClass(indentWriter, ""))
+            {
+                indentWriter.WriteLine($"public static partial class {_information.SourceType?.Name}MapToExtensions");
+                using (indentWriter.Braces())
+                {
+                    WriteMapToExtensionMethod(indentWriter);
 
-            WriteMapToExtensionMethod(indentWriter);
-
-            WriteEnumerableMapToExtensionMethod(indentWriter);
-
-            WriteCloseStaticClass(indentWriter);
-
-            WriteInjectableMapperClass(indentWriter);
-
-            WriteCloseNamespace(indentWriter);
+                    WriteEnumerableMapToExtensionMethod(indentWriter);
+                }
+                WriteInjectableMapperClass(indentWriter);
+            }
 
             return SourceText.From(writer.ToString(), Encoding.UTF8);
         }
@@ -53,40 +54,36 @@ namespace GeneratedMapper.Builders
 
             indentWriter.WriteLine($"public static {returnType} {extensionMethodName}({string.Join(", ", mapParameters)})");
 
-            indentWriter.WriteLine("{");
-            indentWriter.Indent++;
-
-            if (_information.SourceType != null && !_information.SourceType.IsValueType)
+            using (indentWriter.Braces())
             {
-                WriteNullCheck(indentWriter, SourceInstanceName, _information.SourceType.ToDisplayString(), _information.DestinationType?.ToDisplayString());
-            }
+                if (_information.SourceType != null && !_information.SourceType.IsValueType)
+                {
+                    WriteNullCheck(indentWriter, SourceInstanceName, _information.SourceType.ToDisplayString(), _information.DestinationType?.ToDisplayString());
+                }
 
-            indentWriter.WriteLines(GenerateCode(_propertyMappingBuilders, map => map.PreConstructionInitialization()), true);
+                indentWriter.WriteLines(GenerateCode(_propertyMappingBuilders, map => map.PreConstructionInitialization()), true);
 
-            indentWriter.WriteLine($"var {TargetInstanceName} = new {_information.DestinationType?.ToDisplayString()}");
-            indentWriter.WriteLine("{");
-            indentWriter.Indent++;
+                indentWriter.WriteLine($"var {TargetInstanceName} = new {_information.DestinationType?.ToDisplayString()}");
+                using (indentWriter.ClassSetters())
+                {
+                    indentWriter.WriteLines(GenerateCode(_propertyMappingBuilders, map => map.InitializerString()));
+                }
 
-            indentWriter.WriteLines(GenerateCode(_propertyMappingBuilders, map => map.InitializerString()));
-
-            indentWriter.Indent--;
-            indentWriter.WriteLine("};");
-            indentWriter.WriteLine();
-
-            if (_information.ConfigurationValues.Customizations.GenerateAfterMapPartial)
-            {
-                var partialArguments = new[] { SourceInstanceName }
-                    .Union(_propertyMappingBuilders.SelectMany(x => x.MapArgumentsRequired().Select(x => x.ToArgument(string.Empty))).Distinct())
-                    .Append(TargetInstanceName);
-
-                indentWriter.WriteLine($"After{extensionMethodName}({string.Join(", ", partialArguments)});");
                 indentWriter.WriteLine();
+
+                if (_information.ConfigurationValues.Customizations.GenerateAfterMapPartial)
+                {
+                    var partialArguments = new[] { SourceInstanceName }
+                        .Union(_propertyMappingBuilders.SelectMany(x => x.MapArgumentsRequired().Select(x => x.ToArgument(string.Empty))).Distinct())
+                        .Append(TargetInstanceName);
+
+                    indentWriter.WriteLine($"After{extensionMethodName}({string.Join(", ", partialArguments)});");
+                    indentWriter.WriteLine();
+                }
+
+                indentWriter.WriteLine($"return {TargetInstanceName};");
             }
-
-            indentWriter.WriteLine($"return {TargetInstanceName};");
-            indentWriter.Indent--;
-            indentWriter.WriteLine("}");
-
+            
             if (_information.ConfigurationValues.Customizations.GenerateAfterMapPartial)
             {
                 var partialParameters = new[] { $"{_information.SourceType?.ToDisplayString()} {PartialSourceInstanceName}" }
@@ -114,31 +111,26 @@ namespace GeneratedMapper.Builders
 
                 indentWriter.WriteLine();
                 indentWriter.WriteLine($"public static {enumerableType} {extensionMethodName}({string.Join(", ", mapEnumerableParameters)})");
-                indentWriter.WriteLine("{");
-                indentWriter.Indent++;
-
-                if (_information.SourceType != null && !_information.SourceType.IsValueType)
+                using (indentWriter.Braces())
                 {
-                    WriteNullCheck(indentWriter, SourceInstanceName, $"IEnumerable<{_information.SourceType.ToDisplayString()}>", $"IEnumerable<{_information.DestinationType?.ToDisplayString()}>");
-                }
+                    if (_information.SourceType != null && !_information.SourceType.IsValueType)
+                    {
+                        WriteNullCheck(indentWriter, SourceInstanceName, $"IEnumerable<{_information.SourceType.ToDisplayString()}>", $"IEnumerable<{_information.DestinationType?.ToDisplayString()}>");
+                    }
 
-                if (_information.IsAsync)
-                {
-                    indentWriter.WriteLine($"foreach (var element in {SourceInstanceName})");
-                    indentWriter.WriteLine("{");
-                    indentWriter.Indent++;
-
-                    indentWriter.WriteLine($"yield return await element.{extensionMethodName}({string.Join(", ", mapToArguments)});");
-
-                    indentWriter.Indent--;
-                    indentWriter.WriteLine("}");
+                    if (_information.IsAsync)
+                    {
+                        indentWriter.WriteLine($"foreach (var element in {SourceInstanceName})");
+                        using (indentWriter.Braces())
+                        {
+                            indentWriter.WriteLine($"yield return await element.{extensionMethodName}({string.Join(", ", mapToArguments)});");
+                        }
+                    }
+                    else
+                    {
+                        indentWriter.WriteLine($"return {SourceInstanceName}.Select(x => x.{extensionMethodName}({string.Join(", ", mapToArguments)}));");
+                    }
                 }
-                else
-                {
-                    indentWriter.WriteLine($"return {SourceInstanceName}.Select(x => x.{extensionMethodName}({string.Join(", ", mapToArguments)}));");
-                }
-                indentWriter.Indent--;
-                indentWriter.WriteLine("}");
             }
         }
 
@@ -154,57 +146,50 @@ namespace GeneratedMapper.Builders
 
                 indentWriter.WriteLine();
                 indentWriter.WriteLine($"public class {className} : IMapper<{_information.SourceType?.ToDisplayString()}, {_information.DestinationType?.ToDisplayString()}>");
-                indentWriter.WriteLine("{");
-                indentWriter.Indent++;
-
-                var constructorArguments = arguments.Select(x => x.ToMethodParameter(string.Empty)).Distinct();
-                var privateFields = arguments.Select(x => $"private readonly {x.TypeName} _{x.ParameterName};").Distinct();
-                var privateFieldAssignments = arguments.Select(x => $"_{x.ParameterName} = {x.ParameterName};").Distinct();
-                var mapParameters = arguments.Select(x => $"_{x.ParameterName}").Distinct();
-
-                if (constructorArguments.Any())
+                using (indentWriter.Braces())
                 {
-                    foreach (var privateField in privateFields)
+                    var constructorArguments = arguments.Select(x => x.ToMethodParameter(string.Empty)).Distinct();
+                    var privateFields = arguments.Select(x => $"private readonly {x.TypeName} _{x.ParameterName};").Distinct();
+                    var privateFieldAssignments = arguments.Select(x => $"_{x.ParameterName} = {x.ParameterName};").Distinct();
+                    var mapParameters = arguments.Select(x => $"_{x.ParameterName}").Distinct();
+
+                    if (constructorArguments.Any())
                     {
-                        indentWriter.WriteLine(privateField);
+                        foreach (var privateField in privateFields)
+                        {
+                            indentWriter.WriteLine(privateField);
+                        }
+
+                        indentWriter.WriteLine();
+
+                        indentWriter.WriteLine($"public {className}({string.Join(", ", constructorArguments)})");
+                        using (indentWriter.Braces())
+                        {
+                            foreach (var privateFieldAssignment in privateFieldAssignments)
+                            {
+                                indentWriter.WriteLine(privateFieldAssignment);
+                            }
+                        }
+                        indentWriter.WriteLine();
                     }
 
-                    indentWriter.WriteLine();
+                    var async = _information.IsAsync ? $"async " : $"";
+                    var callToMapMethod = _information.IsAsync
+                        ? $"await {fromExpression}.MapTo{_information.DestinationType?.Name}Async({string.Join(", ", mapParameters)})"
+                        : $"Task.FromResult({fromExpression}.MapTo{_information.DestinationType?.Name}({string.Join(", ", mapParameters)}))";
 
-                    indentWriter.WriteLine($"public {className}({string.Join(", ", constructorArguments)})");
-                    indentWriter.WriteLine("{");
-                    indentWriter.Indent++;
-
-                    foreach (var privateFieldAssignment in privateFieldAssignments)
-                    {
-                        indentWriter.WriteLine(privateFieldAssignment);
-                    }
-
-                    indentWriter.Indent--;
-                    indentWriter.WriteLine("}");
-                    indentWriter.WriteLine();
+                    indentWriter.WriteLine($"public {async}Task<{_information.DestinationType?.ToDisplayString()}> MapAsync({_information.SourceType?.ToDisplayString()} from) => {callToMapMethod};");
                 }
-
-                var async = _information.IsAsync ? $"async " : $"";
-                var callToMapMethod = _information.IsAsync
-                    ? $"await {fromExpression}.MapTo{_information.DestinationType?.Name}Async({string.Join(", ", mapParameters)})"
-                    : $"Task.FromResult({fromExpression}.MapTo{_information.DestinationType?.Name}({string.Join(", ", mapParameters)}))";
-
-                indentWriter.WriteLine($"public {async}Task<{_information.DestinationType?.ToDisplayString()}> MapAsync({_information.SourceType?.ToDisplayString()} from) => {callToMapMethod};");
-
-                indentWriter.Indent--;
-                indentWriter.WriteLine("}");
             }
         }
 
         private static void WriteNullCheck(IndentedTextWriter indentWriter, string instanceName, string sourceType, string? destinationType)
         {
             indentWriter.WriteLine($"if ({instanceName} is null)");
-            indentWriter.WriteLine("{");
-            indentWriter.Indent++;
-            indentWriter.WriteLine($@"throw new ArgumentNullException(nameof(self), ""{sourceType} -> {destinationType}: Source is null."");");
-            indentWriter.Indent--;
-            indentWriter.WriteLine("}");
+            using (indentWriter.Braces())
+            {
+                indentWriter.WriteLine($@"throw new ArgumentNullException(nameof(self), ""{sourceType} -> {destinationType}: Source is null."");");
+            }
             indentWriter.WriteLine();
         }
     }

--- a/src/GeneratedMapper/Configurations/MapperCustomizations.cs
+++ b/src/GeneratedMapper/Configurations/MapperCustomizations.cs
@@ -7,7 +7,6 @@
         public string[] NamespacesToInclude { get; set; } = new string[0];
         public bool GenerateEnumerableMethods { get; set; } = true;
         public bool GenerateExpressions { get; set; }
-        public bool GenerateAfterMapPartial { get; set; } = true;
         public bool GenerateInjectableMappers { get; set; }
     }
 }

--- a/src/GeneratedMapper/Extensions/IndentWriterExtensions.cs
+++ b/src/GeneratedMapper/Extensions/IndentWriterExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.CodeDom.Compiler;
 
-namespace GeneratedMapper.Helpers
+namespace GeneratedMapper.Extensions
 {
     public static class IndentWriterExtensions
     {

--- a/src/GeneratedMapper/Helpers/IndentWriterExtensions.cs
+++ b/src/GeneratedMapper/Helpers/IndentWriterExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.CodeDom.Compiler;
+
+namespace GeneratedMapper.Helpers
+{
+    public static class IndentWriterExtensions
+    {
+        public static IDisposable NoIndent(this IndentedTextWriter indentWriter) => new IndentNothing();
+        public static IDisposable Indent(this IndentedTextWriter indentWriter) => new IndentDisposable(indentWriter);
+        public static IDisposable Braces(this IndentedTextWriter indentWriter) => new IndentDisposable(indentWriter, "{", "}");
+        public static IDisposable ClassSetters(this IndentedTextWriter indentWriter) => new IndentDisposable(indentWriter, "{", "};");
+        private class IndentDisposable : IDisposable
+        {
+            private readonly IndentedTextWriter _indentWriter;
+            private readonly string _after;
+
+            public IndentDisposable(IndentedTextWriter indentWriter, string before = null, string after = null)
+            {
+                _indentWriter = indentWriter;
+                _after = after;
+                if(before != null)
+                {
+                    _indentWriter.WriteLine(before);
+                }
+                _indentWriter.Indent++;
+            }
+
+            public void Dispose()
+            {
+                _indentWriter.Indent--;
+                if(_after != null)
+                {
+                    _indentWriter.WriteLine(_after);
+                }
+            }
+        }
+
+        private class IndentNothing : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/src/GeneratedMapper/Information/AfterMapInformation.cs
+++ b/src/GeneratedMapper/Information/AfterMapInformation.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.Collections.Generic;
+using System.Linq;
+using GeneratedMapper.Parsers;
+using Microsoft.CodeAnalysis;
 
 namespace GeneratedMapper.Information
 {
@@ -6,19 +9,15 @@ namespace GeneratedMapper.Information
     {
         public IMethodSymbol MethodSymbol { get; }
 
-        public AfterMapInformation(IMethodSymbol methodSymbol)
+        public AfterMapInformation(IMethodSymbol methodSymbol, ParameterParser parameterParser)
         {
             MethodSymbol = methodSymbol;
-            PartOfType = methodSymbol.ContainingType;
-            MethodName = methodSymbol.Name;
-            SourceType = methodSymbol.Parameters[0].Type;
-            DestinationType = methodSymbol.Parameters[1].Type;
+            Parameters = parameterParser.ParseMethodParameters(methodSymbol.Parameters);
         }
 
-        public ITypeSymbol PartOfType { get; }
-        public string MethodName { get; }
-        public ITypeSymbol? SourceType { get; }
-        public ITypeSymbol? DestinationType { get; }
-        
+        public ITypeSymbol PartOfType => MethodSymbol.ContainingType;
+        public string MethodName => MethodSymbol.Name;
+        public IEnumerable<ITypeSymbol?> ParameterTypes => MethodSymbol.Parameters.Select(_ => _.Type);
+        public List<ParameterInformation> Parameters { get; }
     }
 }

--- a/src/GeneratedMapper/Information/AfterMapInformation.cs
+++ b/src/GeneratedMapper/Information/AfterMapInformation.cs
@@ -17,7 +17,7 @@ namespace GeneratedMapper.Information
 
         public ITypeSymbol PartOfType => MethodSymbol.ContainingType;
         public string MethodName => MethodSymbol.Name;
-        public IEnumerable<ITypeSymbol?> ParameterTypes => MethodSymbol.Parameters.Select(_ => _.Type);
+        public IEnumerable<ITypeSymbol?> ParameterTypes => MethodSymbol.Parameters.Select(x => x.Type);
         public List<ParameterInformation> Parameters { get; }
     }
 }

--- a/src/GeneratedMapper/Information/AfterMapInformation.cs
+++ b/src/GeneratedMapper/Information/AfterMapInformation.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace GeneratedMapper.Information
+{
+    internal sealed class AfterMapInformation
+    {
+        public IMethodSymbol MethodSymbol { get; }
+
+        public AfterMapInformation(IMethodSymbol methodSymbol)
+        {
+            MethodSymbol = methodSymbol;
+            PartOfType = methodSymbol.ContainingType;
+            MethodName = methodSymbol.Name;
+            SourceType = methodSymbol.Parameters[0].Type;
+            DestinationType = methodSymbol.Parameters[1].Type;
+        }
+
+        public ITypeSymbol PartOfType { get; }
+        public string MethodName { get; }
+        public ITypeSymbol? SourceType { get; }
+        public ITypeSymbol? DestinationType { get; }
+        
+    }
+}

--- a/src/GeneratedMapper/Information/MappingInformation.cs
+++ b/src/GeneratedMapper/Information/MappingInformation.cs
@@ -59,6 +59,7 @@ namespace GeneratedMapper.Information
         }
 
         public IEnumerable<PropertyMappingInformation> Mappings => _propertyMappings;
+        public List<AfterMapInformation> AfterMaps { get; } = new();
 
         public MappingInformation AddProperty(PropertyMappingInformation propertyMapping)
         {

--- a/src/GeneratedMapper/MapperGenerator.cs
+++ b/src/GeneratedMapper/MapperGenerator.cs
@@ -70,7 +70,7 @@ namespace GeneratedMapper
             var customizations = FindMapperCustomizations(context);
 
             var parser = new MappingAttributeParser(context, new PropertyParser(context, new ParameterParser(context), extensionMethods));
-
+            
             var foundMappings = new List<MappingInformation>();
 
             if (context.SyntaxReceiver is MapAttributeReceiver attributeReceiver)
@@ -122,7 +122,7 @@ namespace GeneratedMapper
         }
         private static List<AfterMapInformation> FindAfterMaps(GeneratorExecutionContext context)
         {
-            var parser = new AfterMapParser();
+            var parser = new AfterMapParser(new ParameterParser(context));
 
             var foundExtensionMethods = new List<AfterMapInformation>();
 

--- a/src/GeneratedMapper/Parsers/AfterMapParser.cs
+++ b/src/GeneratedMapper/Parsers/AfterMapParser.cs
@@ -7,28 +7,17 @@ namespace GeneratedMapper.Parsers
 {
     internal sealed class AfterMapParser
     {
-        public List<AfterMapInformation> ParseType(ITypeSymbol type)
+        private readonly ParameterParser _parameterParser;
+
+        public AfterMapParser(ParameterParser parameterParser)
         {
-            var afterMapMethods = new List<AfterMapInformation>();
-
-            foreach (var method in type.GetMembers().OfType<IMethodSymbol>()
-                .Where(x => x.Parameters.Length == 2 && x.ReturnType.Name == "Void" && x.Name.Contains("AfterMap")))
-            {
-                var afterMap = new AfterMapInformation(method);
-
-                // multiple overloads for mapping the same type to the same destination type is not allowed as it is impossible to determine which one the user wants to use
-                // if really needed, multiple mappings should be generated per such overload, but can become quite complicated
-                if (afterMapMethods.Any(e => afterMap.MethodName == e.MethodName &&
-                                             afterMap.SourceType.Equals(e.SourceType, SymbolEqualityComparer.Default) &&
-                                             afterMap.DestinationType.Equals(e.DestinationType, SymbolEqualityComparer.Default)))
-                {
-                    continue;
-                }
-
-                afterMapMethods.Add(afterMap);
-            }
-
-            return afterMapMethods;
+            _parameterParser = parameterParser;
         }
+        public List<AfterMapInformation> ParseType(ITypeSymbol type) =>
+            type.GetMembers()
+                .OfType<IMethodSymbol>()
+                .Where(x => x.Parameters.Length >= 2 && x.ReturnType.Name == "Void" && x.Name.Contains("AfterMap"))
+                .Select(method => new AfterMapInformation(method, _parameterParser))
+                .ToList();
     }
 }

--- a/src/GeneratedMapper/Parsers/AfterMapParser.cs
+++ b/src/GeneratedMapper/Parsers/AfterMapParser.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using GeneratedMapper.Information;
+using Microsoft.CodeAnalysis;
+
+namespace GeneratedMapper.Parsers
+{
+    internal sealed class AfterMapParser
+    {
+        public List<AfterMapInformation> ParseType(ITypeSymbol type)
+        {
+            var afterMapMethods = new List<AfterMapInformation>();
+
+            foreach (var method in type.GetMembers().OfType<IMethodSymbol>()
+                .Where(x => x.Parameters.Length == 2 && x.ReturnType.Name == "Void" && x.Name.Contains("AfterMap")))
+            {
+                var afterMap = new AfterMapInformation(method);
+
+                // multiple overloads for mapping the same type to the same destination type is not allowed as it is impossible to determine which one the user wants to use
+                // if really needed, multiple mappings should be generated per such overload, but can become quite complicated
+                if (afterMapMethods.Any(e => afterMap.MethodName == e.MethodName &&
+                                             afterMap.SourceType.Equals(e.SourceType, SymbolEqualityComparer.Default) &&
+                                             afterMap.DestinationType.Equals(e.DestinationType, SymbolEqualityComparer.Default)))
+                {
+                    continue;
+                }
+
+                afterMapMethods.Add(afterMap);
+            }
+
+            return afterMapMethods;
+        }
+    }
+}

--- a/src/GeneratedMapper/Parsers/MappingAttributeParser.cs
+++ b/src/GeneratedMapper/Parsers/MappingAttributeParser.cs
@@ -125,12 +125,11 @@ namespace GeneratedMapper.Parsers
                     mappingInformation.ReportIssue(DiagnosticsHelper.LeftOverProperty(attributeData, targetType.ToDisplayString(), remainingTargetProperty.Key, attributedType.ToDisplayString()));
                 }
 
-                foreach (var afterMap in afterMapInformations)
+                foreach (var afterMap in afterMapInformations.Where(am =>
+                    am.ParameterTypes.Any(_ => _.Equals(mappingInformation.SourceType)) &&
+                    am.ParameterTypes.Any(_ => _.Equals(mappingInformation.DestinationType))))
                 {
-                    if (afterMap.SourceType.Equals(mappingInformation.SourceType) && afterMap.DestinationType.Equals(mappingInformation.DestinationType))
-                    {
-                        mappingInformation.AfterMaps.Add(afterMap);
-                    }
+                    mappingInformation.AfterMaps.Add(afterMap);
                 }
             }
             catch (ParseException ex)

--- a/src/GeneratedMapper/Parsers/MappingAttributeParser.cs
+++ b/src/GeneratedMapper/Parsers/MappingAttributeParser.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using GeneratedMapper.Attributes;
 using GeneratedMapper.Configurations;
@@ -31,7 +30,8 @@ namespace GeneratedMapper.Parsers
             _propertyParser = propertyParser ?? throw new ArgumentNullException(nameof(propertyParser));
         }
 
-        public MappingInformation ParseAttribute(ConfigurationValues configurationValues, ITypeSymbol attributedType, AttributeData attributeData)
+        public MappingInformation ParseAttribute(ConfigurationValues configurationValues, ITypeSymbol attributedType,
+            AttributeData attributeData, List<AfterMapInformation> afterMapInformations)
         {
             var mappingInformation = new MappingInformation(attributeData, configurationValues);
 
@@ -123,6 +123,14 @@ namespace GeneratedMapper.Parsers
                 foreach (var remainingTargetProperty in targetTypeProperties.Where(x => !destinationPropertyExclusions.Contains(x.Key) && !processedTargetProperties.Contains(x.Key)))
                 {
                     mappingInformation.ReportIssue(DiagnosticsHelper.LeftOverProperty(attributeData, targetType.ToDisplayString(), remainingTargetProperty.Key, attributedType.ToDisplayString()));
+                }
+
+                foreach (var afterMap in afterMapInformations)
+                {
+                    if (afterMap.SourceType.Equals(mappingInformation.SourceType) && afterMap.DestinationType.Equals(mappingInformation.DestinationType))
+                    {
+                        mappingInformation.AfterMaps.Add(afterMap);
+                    }
                 }
             }
             catch (ParseException ex)

--- a/src/GeneratedMapper/Parsers/MappingAttributeParser.cs
+++ b/src/GeneratedMapper/Parsers/MappingAttributeParser.cs
@@ -126,8 +126,8 @@ namespace GeneratedMapper.Parsers
                 }
 
                 foreach (var afterMap in afterMapInformations.Where(am =>
-                    am.ParameterTypes.Any(_ => _.Equals(mappingInformation.SourceType)) &&
-                    am.ParameterTypes.Any(_ => _.Equals(mappingInformation.DestinationType))))
+                    am.ParameterTypes.Any(x => x.Equals(mappingInformation.SourceType)) &&
+                    am.ParameterTypes.Any(x => x.Equals(mappingInformation.DestinationType))))
                 {
                     mappingInformation.AfterMaps.Add(afterMap);
                 }

--- a/src/GeneratedMapper/SyntaxReceivers/MapAttributeReceiver.cs
+++ b/src/GeneratedMapper/SyntaxReceivers/MapAttributeReceiver.cs
@@ -35,7 +35,7 @@ namespace GeneratedMapper.SyntaxReceivers
                 }
 
                 var hasAfterMapMethod = methods.Any(x =>
-                    x.ParameterList.Parameters.Count == 2 &&
+                    x.ParameterList.Parameters.Count >= 2 &&
                     x.Modifiers.Any(m => m.Kind() == SyntaxKind.StaticKeyword) &&
                     (x.ReturnType as PredefinedTypeSyntax)?.Keyword.Text == "void");
                 if (hasAfterMapMethod)


### PR DESCRIPTION
Moves AfterMap from something that's turned on and off, to something that only gets added when user writes code that it will call.
# Changes
- GeneratePartialAfterMap setting completely removed from configuration
- Only Attaches if follows `static void *AfterMap*(TSource *, TDest *)`, with TSource and TDest matching existing mapping
  - Classes with a different name from auto-generated extensions class name get linked up as well
    - If method call isn't public will throw compile time error saying doesn't have permission to call the function
  - Can tell if mapping is successful name with 0 reference changing to 1 reference in VS Pro Code Lens feature
  - If no matching methods found doesn't add AfterMap function call to auto generated code
    - No Partial method call created either, so generated code only calls what's needed
- If multiple matches are found it will run each AfterMap in the order they were found
  - Don't know if this is desired, or should throw diagnostic error saying can only have one valid AfterMap
  - I don't have a preference on this at the moment
- After Maps no longer try to use Resolver and/or Extension method parameters
  - Existing code would pass resolver parameters through to AfterMap and I removed this as I didn't see a point
  - Substring needs start index and I don't know why AfterMap would need to use that as part of the mapping
# Todo
- [x] Discuss if this is a route you want to go
  - This is moving from explicit configuration to implicit convention.
  - People can use anything that has AfterMap vs exact name in order for it to work.
    - Highly flexible based on user preference, but if it ever deviates, can break everything. (At least it will be at compile time)
  - I would want to push this further to Create mappings when you call mapper.
- [x] Is the layout of the code follow the flow of everything else
  - I got it working and all the unit tests to pass, but as far as where it goes in the pipeline, I don't know if it needs to be pushed to the param parser at a higher level and used there, vs keeping it where it is.
- [x] Any features need to be reverted back for whatever reason
  - The Extensions/Resolver parameters being passed in for AfterMap being essential for example
    - Or option to map using them or not using them and figure it out by parameters name and type