### PR TITLE
Expressions should not require resolver parameters 

### DIFF
--- a/src/GeneratedMapper.Tests/CollectionExtensionMethodGeneratorTests.cs
+++ b/src/GeneratedMapper.Tests/CollectionExtensionMethodGeneratorTests.cs
@@ -26,7 +26,6 @@ namespace A {
 
 namespace B {
     public class B { public string[] Prop { get; set; } }
-}
 }",
 @"using System;
 using System.Linq;
@@ -78,7 +77,6 @@ namespace A {
 
 namespace B {
     public class B { public int[] Prop { get; set; } }
-}
 }",
 @"using System;
 using System.Linq;

--- a/src/GeneratedMapper.Tests/ExpressionBasicTests.cs
+++ b/src/GeneratedMapper.Tests/ExpressionBasicTests.cs
@@ -140,7 +140,6 @@ namespace R {
 
 namespace B {
     public class B { public string Name { get; set; } }
-}
 }",
 @"using System;
 
@@ -491,7 +490,6 @@ namespace R {
 
 namespace B {
     public class B { public string Name { get; set; } public string ResolvedName { get; set; } public B Sub { get; set; } }
-}
 }",
 @"using System;
 

--- a/src/GeneratedMapper/Builders/ExpressionBuilder.cs
+++ b/src/GeneratedMapper/Builders/ExpressionBuilder.cs
@@ -25,13 +25,13 @@ namespace GeneratedMapper.Builders
             using var indentWriter = new IndentedTextWriter(writer,
                 _information.ConfigurationValues.IndentStyle == IndentStyle.Tab ? "\t" : new string(' ', (int)_information.ConfigurationValues.IndentSize));
 
-            WriteUsingNamespaces(indentWriter, 
+            WriteUsingNamespaces(indentWriter,
                 new string[] { "System", "System.Linq.Expressions" }
                     .Union(_information.Mappings.Where(x => !x.IsAsync)
                     .SelectMany(x => x.NamespacesUsed)),
                 allowNamespacesForAsync: false);
             WriteOptionalNullableEnablePragma(indentWriter);
-            using(WriteOpenNamespace(indentWriter, ".Expressions"))
+            using (WriteOpenNamespace(indentWriter, ".Expressions"))
             {
                 indentWriter.WriteLine($"public static partial class {_information.SourceType?.Name ?? ""}");
                 using (indentWriter.Braces())
@@ -45,7 +45,12 @@ namespace GeneratedMapper.Builders
 
         public void WriteMethod(IndentedTextWriter indentWriter)
         {
-            var mapParameters = _information.Mappings.Where(x => !x.IsAsync).SelectMany(x => x.MapParametersRequired.Select(x => x.ToMethodParameter(string.Empty))).Distinct();
+            var mapParameters = _information.Mappings
+                .Where(x => !x.IsAsync)
+                .SelectMany(x => x.MapParametersRequired
+                    .Where(x => x.Source != ParameterSource.Resolver)
+                    .Select(x => x.ToMethodParameter(string.Empty)))
+                .Distinct();
 
             indentWriter.WriteLine($"public static Expression<Func<{_information.SourceType?.ToDisplayString()}, {_information.DestinationType?.ToDisplayString()}>> To{_information.DestinationType?.Name}({string.Join(", ", mapParameters)}) => ({_information.SourceType?.ToDisplayString()} {SourceInstanceName}) =>");
             using (indentWriter.Indent())

--- a/src/GeneratedMapper/Builders/ExpressionContext.cs
+++ b/src/GeneratedMapper/Builders/ExpressionContext.cs
@@ -19,6 +19,4 @@
         public ExpressionContext<TInfo> NestCall<TInfo>(TInfo information, string propertyName)
             => new ExpressionContext<TInfo>(information, $"{SourceInstanceName}.{propertyName}", MaxRecursion - 1);
     }
-
-
 }

--- a/src/GeneratedMapper/Enums/ParameterSource.cs
+++ b/src/GeneratedMapper/Enums/ParameterSource.cs
@@ -1,0 +1,9 @@
+﻿namespace GeneratedMapper.Enums
+{
+    internal enum ParameterSource
+    {
+        Resolver,
+        ExtensionMethod,
+        Method
+    }
+}

--- a/src/GeneratedMapper/GeneratedMapper.csproj
+++ b/src/GeneratedMapper/GeneratedMapper.csproj
@@ -5,7 +5,7 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.6.0</Version>
+    <Version>3.0.0</Version>
     <Authors>Thomas Bleijendaal</Authors>
     <Company>Thomas Bleijendaal</Company>
     <Product>Generated Mapper</Product>

--- a/src/GeneratedMapper/Information/ParameterInformation.cs
+++ b/src/GeneratedMapper/Information/ParameterInformation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using GeneratedMapper.Enums;
 using GeneratedMapper.Extensions;
 
 namespace GeneratedMapper.Information
@@ -10,13 +11,15 @@ namespace GeneratedMapper.Information
             string typeName,
             string @namespace,
             bool isNullable,
-            string? defaultValue)
+            string? defaultValue,
+            ParameterSource source)
         {
             ParameterName = parameterName ?? throw new ArgumentNullException(nameof(parameterName));
             TypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
             Namespace = @namespace ?? throw new ArgumentNullException(nameof(@namespace));
             IsNullable = isNullable;
             DefaultValue = defaultValue;
+            Source = source;
         }
 
         public string ParameterName { get; private set; }
@@ -24,9 +27,10 @@ namespace GeneratedMapper.Information
         public string Namespace { get; private set; }
         public bool IsNullable { get; }
         public string? DefaultValue { get; }
+        public ParameterSource Source { get; set; }
 
         public ParameterInformation CopyWithPrefix(string prefix)
-            => new ParameterInformation(ToArgument(prefix), TypeName, Namespace, IsNullable, DefaultValue);
+            => new ParameterInformation(ToArgument(prefix), TypeName, Namespace, IsNullable, DefaultValue, Source);
 
         public string ToMethodParameter(string prefix)
             => $"{TypeName} {ToArgument(prefix)}{(DefaultValue == null ? "" : $" = { DefaultValue}")}";

--- a/src/GeneratedMapper/Parsers/ExtensionMethodParser.cs
+++ b/src/GeneratedMapper/Parsers/ExtensionMethodParser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using GeneratedMapper.Enums;
 using GeneratedMapper.Information;
 using Microsoft.CodeAnalysis;
 
@@ -53,7 +54,7 @@ namespace GeneratedMapper.Parsers
                     extensionMethods.Add(new ExtensionMethodInformation(type, method.Name)
                         .Accepts(acceptType)
                         .Returns(returnType, isAsyncMethod)
-                        .HasParameters(_argumentParser.ParseMethodParameters(method.Parameters.Skip(1))));
+                        .HasParameters(_argumentParser.ParseMethodParameters(method.Parameters.Skip(1), ParameterSource.ExtensionMethod)));
                 }
             }
 

--- a/src/GeneratedMapper/Parsers/ParameterParser.cs
+++ b/src/GeneratedMapper/Parsers/ParameterParser.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using GeneratedMapper.Enums;
 using GeneratedMapper.Information;
 using Microsoft.CodeAnalysis;
 
@@ -16,7 +17,7 @@ namespace GeneratedMapper.Parsers
             _stringType = context.Compilation.GetTypeByMetadataName("System.String") ?? throw new InvalidOperationException("Cannot find System.String");
         }
 
-        public IEnumerable<ParameterInformation> ParseConstructorParameters(INamedTypeSymbol type)
+        public IEnumerable<ParameterInformation> ParseConstructorParameters(INamedTypeSymbol type, ParameterSource parameterSource)
         {
             var resolverConstructor = type.Constructors
                 .Where(x => x.DeclaredAccessibility == Accessibility.Public)
@@ -28,10 +29,10 @@ namespace GeneratedMapper.Parsers
                 return Enumerable.Empty<ParameterInformation>();
             }
 
-            return ParseMethodParameters(resolverConstructor.Parameters).ToImmutableArray();
+            return ParseMethodParameters(resolverConstructor.Parameters, parameterSource).ToImmutableArray();
         }
 
-        public List<ParameterInformation> ParseMethodParameters(IEnumerable<IParameterSymbol> parameters)
+        public List<ParameterInformation> ParseMethodParameters(IEnumerable<IParameterSymbol> parameters, ParameterSource parameterSource)
         {
             var list = new List<ParameterInformation>();
 
@@ -61,7 +62,8 @@ namespace GeneratedMapper.Parsers
                     parameter.Type.ToDisplayString(),
                     @namespace,
                     parameter.NullableAnnotation == NullableAnnotation.Annotated,
-                    defaultValueString));
+                    defaultValueString,
+                    parameterSource));
             }
 
             return list;

--- a/src/GeneratedMapper/Parsers/PropertyParser.cs
+++ b/src/GeneratedMapper/Parsers/PropertyParser.cs
@@ -196,7 +196,7 @@ namespace GeneratedMapper.Parsers
 
                 propertyMapping.UsingResolver(resolverName,
                     resolverType.ToDisplayString(),
-                    _parameterParser.ParseConstructorParameters(resolverType));
+                    _parameterParser.ParseConstructorParameters(resolverType, ParameterSource.Resolver));
             }
             else if (mapWithAttribute?.ConstructorArgument<string>(1) is string propertyMethodToCall)
             {
@@ -208,7 +208,7 @@ namespace GeneratedMapper.Parsers
                         .OrderBy(x => x.Parameters.Length)
                         .FirstOrDefault() is IMethodSymbol sourcePropertyMethod)
                 {
-                    propertyMapping.UsingMethod(propertyMethodToCall, default, _parameterParser.ParseMethodParameters(sourcePropertyMethod.Parameters));
+                    propertyMapping.UsingMethod(propertyMethodToCall, default, _parameterParser.ParseMethodParameters(sourcePropertyMethod.Parameters, ParameterSource.Method));
                 }
                 else if (_extensionMethods.FirstOrDefault(extensionMethod => extensionMethod.MethodName == propertyMethodToCall &&
                     sourceType.Equals(extensionMethod.AcceptsType, SymbolEqualityComparer.Default) &&


### PR DESCRIPTION
Resolvers are not supported in expressions and the generated expressions should not require parameters for those resolvers.