### PR TITLE
Make Generic MapTo call that will generate mapping code

### DIFF
--- a/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/From.cs
+++ b/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/From.cs
@@ -1,0 +1,11 @@
+﻿using GeneratedMapper.Attributes;
+
+namespace GeneratedMapper.Tests.CompilerTests.ExtensionMethod
+{
+    [MapTo(typeof(MapToTo)), IgnoreInTarget(nameof(MapToTo.ToIgnore))]
+    [MapTo(typeof(ProjectMapToTo), Index = 2), IgnoreInTarget(nameof(MapToTo.ToIgnore), Index = 2)]
+    public class From
+    {
+        public int Id { get; set; }
+    }
+}

--- a/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/MapFromTo.cs
+++ b/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/MapFromTo.cs
@@ -1,0 +1,12 @@
+﻿using GeneratedMapper.Attributes;
+
+namespace GeneratedMapper.Tests.CompilerTests.ExtensionMethod
+{
+    [MapFrom(typeof(From))]
+    public class MapFromTo
+    {
+        public int Id { get; set; }
+        [Ignore]
+        public int ToIgnore { get; set; }
+    }
+}

--- a/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/MapToTo.cs
+++ b/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/MapToTo.cs
@@ -1,0 +1,8 @@
+﻿namespace GeneratedMapper.Tests.CompilerTests.ExtensionMethod
+{
+    public class MapToTo
+    {
+        public int Id { get; set; }
+        public int ToIgnore { get; set; }
+    }
+}

--- a/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/ProjectMapFromTo.cs
+++ b/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/ProjectMapFromTo.cs
@@ -1,0 +1,12 @@
+﻿using GeneratedMapper.Attributes;
+
+namespace GeneratedMapper.Tests.CompilerTests.ExtensionMethod
+{
+    [MapFrom(typeof(From))]
+    public class ProjectMapFromTo
+    {
+        public int Id { get; set; }
+        [Ignore]
+        public int ToIgnore { get; set; }
+    }
+}

--- a/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/ProjectMapToTo.cs
+++ b/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/ProjectMapToTo.cs
@@ -1,0 +1,8 @@
+﻿namespace GeneratedMapper.Tests.CompilerTests.ExtensionMethod
+{
+    public class ProjectMapToTo
+    {
+        public int Id { get; set; }
+        public int ToIgnore { get; set; }
+    }
+}

--- a/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/ProjectTo.cs
+++ b/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/ProjectTo.cs
@@ -1,0 +1,7 @@
+﻿namespace GeneratedMapper.Tests.CompilerTests.ExtensionMethod
+{
+    public class ProjectTo
+    {
+        public int Id { get; set; }
+    }
+}

--- a/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/Tests.cs
+++ b/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/Tests.cs
@@ -1,27 +1,38 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
+using GeneratedMapper.Attributes;
 using GeneratedMapper.Extensions;
 using NUnit.Framework;
 
 namespace GeneratedMapper.Tests.CompilerTests.ExtensionMethod
 {
+    //[MapTo(typeof(To))]
+    public class From
+    {
+        public int Id { get; set; }
+    }
+
+    //[MapFrom(typeof(From))]
+    public class To
+    {
+        public int Id { get; set; }
+        //public string Fail { get; set; }
+    }
+    public class To2
+    {
+        public int Id { get; set; }
+        //public string Fail { get; set; }
+    }
+
     public class Tests
     {
-        public class From
-        {
-            public int Id { get; set; }
-        }
-
-        public class To
-        {
-            public int Id { get; set; }
-        }
-
         [Test]
         public void MapTo_Create_Mapper_Test()
         {
             var destination = new From(){Id = 5}.MapTo<From, To>();
             destination.Id.Should().Be(5);
+            var destination2 = new From() { Id = 10 }.MapTo<From, To2>();
+            destination2.Id.Should().Be(10);
         }
-
     }
 }

--- a/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/Tests.cs
+++ b/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/Tests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using FluentAssertions;
 using GeneratedMapper.Attributes;
 using GeneratedMapper.Extensions;
@@ -33,6 +34,11 @@ namespace GeneratedMapper.Tests.CompilerTests.ExtensionMethod
             destination.Id.Should().Be(5);
             var destination2 = new From() { Id = 10 }.MapTo<From, To2>();
             destination2.Id.Should().Be(10);
+
+            var query = new From[]{new(){ Id = 5}}.AsQueryable().ProjectTo<From, To>().ToList();
+            query[0].Id.Should().Be(5);
+
+            var query2 = new To[] { new() { Id = 5 } }.AsQueryable().ProjectTo<To, From>().ToList();
         }
     }
 }

--- a/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/Tests.cs
+++ b/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/Tests.cs
@@ -1,0 +1,27 @@
+﻿using FluentAssertions;
+using GeneratedMapper.Extensions;
+using NUnit.Framework;
+
+namespace GeneratedMapper.Tests.CompilerTests.ExtensionMethod
+{
+    public class Tests
+    {
+        public class From
+        {
+            public int Id { get; set; }
+        }
+
+        public class To
+        {
+            public int Id { get; set; }
+        }
+
+        [Test]
+        public void MapTo_Create_Mapper_Test()
+        {
+            var destination = new From(){Id = 5}.MapTo<From, To>();
+            destination.Id.Should().Be(5);
+        }
+
+    }
+}

--- a/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/Tests.cs
+++ b/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/Tests.cs
@@ -1,44 +1,52 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using FluentAssertions;
-using GeneratedMapper.Attributes;
 using GeneratedMapper.Extensions;
 using NUnit.Framework;
 
 namespace GeneratedMapper.Tests.CompilerTests.ExtensionMethod
 {
-    //[MapTo(typeof(To))]
-    public class From
-    {
-        public int Id { get; set; }
-    }
-
-    //[MapFrom(typeof(From))]
-    public class To
-    {
-        public int Id { get; set; }
-        //public string Fail { get; set; }
-    }
-    public class To2
-    {
-        public int Id { get; set; }
-        //public string Fail { get; set; }
-    }
-
     public class Tests
     {
         [Test]
-        public void MapTo_Create_Mapper_Test()
+        public void MapTo_With_No_Map_Attributes_Uses_DefaultConfig()
         {
-            var destination = new From(){Id = 5}.MapTo<From, To>();
+            var destination = new From {Id = 5}.MapTo<From, To>();
             destination.Id.Should().Be(5);
-            var destination2 = new From() { Id = 10 }.MapTo<From, To2>();
+        }
+
+        [Test]
+        public void MapTo_With_MapToAttribute_Uses_MapToAttributeConfig()
+        {
+            var destination = new From {Id = 5}.MapTo<From, MapToTo>();
+            destination.Id.Should().Be(5);
+        }
+
+        [Test]
+        public void MapTo_With_MapFromAttribute_Uses_MapFromAttributeConfig()
+        {
+            var destination2 = new From { Id = 10 }.MapTo<From, MapFromTo>();
             destination2.Id.Should().Be(10);
+        }
 
-            var query = new From[]{new(){ Id = 5}}.AsQueryable().ProjectTo<From, To>().ToList();
+        [Test]
+        public void ProjectTo_With_No_Map_Attributes_DefaultConfig()
+        {
+            var query = new From[] { new() { Id = 5 } }.AsQueryable().ProjectTo<From, ProjectTo>().ToList();
             query[0].Id.Should().Be(5);
+        }
 
-            var query2 = new To[] { new() { Id = 5 } }.AsQueryable().ProjectTo<To, From>().ToList();
+        [Test]
+        public void ProjectTo_With_MapToAttribute_MapToAttributeConfig()
+        {
+            var query = new From[] { new() { Id = 5 } }.AsQueryable().ProjectTo<From, ProjectMapToTo>().ToList();
+            query[0].Id.Should().Be(5);
+        }
+
+        [Test]
+        public void ProjectTo_With_MapFromAttribute_MapFromAttributeConfig()
+        {
+            var query = new From[] { new() { Id = 5 } }.AsQueryable().ProjectTo<From, ProjectMapFromTo>().ToList();
+            query[0].Id.Should().Be(5);
         }
     }
 }

--- a/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/To.cs
+++ b/src/GeneratedMapper.Tests/CompilerTests/ExtensionMethod/To.cs
@@ -1,0 +1,7 @@
+﻿namespace GeneratedMapper.Tests.CompilerTests.ExtensionMethod
+{
+    public class To
+    {
+        public int Id { get; set; }
+    }
+}

--- a/src/GeneratedMapper.Tests/MapToExtensionMethodTests.cs
+++ b/src/GeneratedMapper.Tests/MapToExtensionMethodTests.cs
@@ -61,10 +61,10 @@ namespace GeneratedMapper.Extensions
                     {
                         ""Test.B"" =>
                             Test.AMapToExtensions.MapToB(a) is TDestination b ? b : default,
-                        _ => throw new NotSupportedException(""Mapping is not configured"")
+                        _ => throw new NotSupportedException($""{typeof(TSource).FullName} -> {typeof(TDestination).FullName}: Map is not configured."")
                     };
                 default:
-                    throw new NotSupportedException(""Mapping is not configured"");
+                    throw new NotSupportedException($""{typeof(TSource).FullName} -> {typeof(TDestination).FullName}: Map is not configured."");
             }
         }
     }

--- a/src/GeneratedMapper.Tests/MapToExtensionMethodTests.cs
+++ b/src/GeneratedMapper.Tests/MapToExtensionMethodTests.cs
@@ -1,0 +1,99 @@
+﻿using GeneratedMapper.Tests.Helpers;
+using NUnit.Framework;
+
+namespace GeneratedMapper.Tests
+{
+    public class MapToExtensionMethodTests
+    {
+        [Test]
+        public void MapTo_With_NoMapAttributes_Only_Generates_MapTo_Single_Item()
+        {
+            GeneratorTestHelper.TestGeneratedCode(@"using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using GeneratedMapper.Attributes;
+
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = true, GenerateExpressions = true)]
+namespace Test
+{
+    public class A { public int Id { get; set; }}
+    public class B { public int Id { get; set; }}
+
+    public class MapToClass { public B MapToCall() => new A().MapTo<A,B>(); }
+}",
+@"using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Test
+{
+    public static partial class AMapToExtensions
+    {
+        public static Test.B MapToB(this Test.A self)
+        {
+            if (self is null)
+            {
+                throw new ArgumentNullException(nameof(self), ""Test.A -> Test.B: Source is null."");
+            }
+            
+            var target = new Test.B
+            {
+                Id = self.Id,
+            };
+            
+            return target;
+        }
+    }
+}
+",
+@"using System;
+
+namespace GeneratedMapper.Extensions
+{
+    public static class MapExtensions
+    {
+        public static TDestination MapTo<TSource, TDestination>(this TSource source)
+        {
+            switch (source)
+            {
+                case Test.A a:
+                    return typeof(TDestination).FullName switch
+                    {
+                        ""Test.B"" =>
+                            Test.AMapToExtensions.MapToB(a) is TDestination b ? b : default,
+                        _ => throw new NotSupportedException(""Mapping is not configured"")
+                    };
+                default:
+                    throw new NotSupportedException(""Mapping is not configured"");
+            }
+        }
+    }
+}
+");
+        }
+
+        [Test]
+        public void MapTo_Validation_Failed_Reports_Create_MapToAttribute_With_MapTo_Location()
+        {
+            GeneratorTestHelper.TestReportedDiagnosticLocation(@"using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using GeneratedMapper.Attributes;
+
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = true, GenerateExpressions = true)]
+namespace Test
+{
+    public class A { public int Id { get; set; }}
+    public class B
+    {
+        public int Id { get; set; }
+        public string NotMapped { get; set; }
+    }
+
+    public class MapToClass { public B MapToCall() => new A().MapTo<A,B>(); }
+}",
+                "GM0017", 
+                "MapTo<A,B>");
+        }
+    }
+}

--- a/src/GeneratedMapper.Tests/ProjectToExtensionMethodTests.cs
+++ b/src/GeneratedMapper.Tests/ProjectToExtensionMethodTests.cs
@@ -45,7 +45,7 @@ using System.Linq;
 
 namespace GeneratedMapper.Extensions
 {
-    public static class MapExtension
+    public static class ProjectExtensions
     {
         public static IQueryable<TDestination> ProjectTo<TSource, TDestination>(this IQueryable<TSource> source)
         {
@@ -56,10 +56,10 @@ namespace GeneratedMapper.Extensions
                     {
                         ""Test.B"" =>
                             a.Select(Test.Expressions.A.ToB()) is IQueryable<TDestination> b ? b : default,
-                        _ => throw new NotSupportedException(""Projection is not configured"")
+                        _ => throw new NotSupportedException($""{typeof(TSource).FullName} -> {typeof(TDestination).FullName}: Project is not configured."")
                     };
                 default:
-                    throw new NotSupportedException(""Projection is not configured"");
+                    throw new NotSupportedException($""{typeof(TSource).FullName} -> {typeof(TDestination).FullName}: Project is not configured."");
             }
         }
     }

--- a/src/GeneratedMapper.Tests/ProjectToExtensionMethodTests.cs
+++ b/src/GeneratedMapper.Tests/ProjectToExtensionMethodTests.cs
@@ -1,0 +1,95 @@
+﻿using GeneratedMapper.Tests.Helpers;
+using NUnit.Framework;
+
+namespace GeneratedMapper.Tests
+{
+    public class ProjectToExtensionMethodTests
+    {
+        [Test]
+        public void ProjectTo_With_NoMapAttributes_Only_Generates_ProjectTo_Single_Item()
+        {
+            GeneratorTestHelper.TestGeneratedCode(@"using System;
+using System.Linq;
+using System.Globalization;
+using System.Threading.Tasks;
+using GeneratedMapper.Attributes;
+
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = true, GenerateExpressions = true)]
+namespace Test
+{
+    public class A { public int Id { get; set; }}
+    public class B { public int Id { get; set; }}
+
+    public class MapToClass { public B[] MapToCall() => new A[] { new() { Id = 5 } }.AsQueryable().ProjectTo<A,B>().ToArray(); }
+}",
+                @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Test.Expressions
+{
+    public static partial class A
+    {
+        public static Expression<Func<Test.A, Test.B>> ToB() => (Test.A self) =>
+            new Test.B
+            {
+                Id = self.Id,
+            };
+    }
+}
+",
+                GeneratorTestHelper.MapExtensionsDefaultText,
+                @"using System;
+using System.Linq;
+
+namespace GeneratedMapper.Extensions
+{
+    public static class MapExtension
+    {
+        public static IQueryable<TDestination> ProjectTo<TSource, TDestination>(this IQueryable<TSource> source)
+        {
+            switch (source)
+            {
+                case IQueryable<Test.A> a:
+                    return typeof(TDestination).FullName switch
+                    {
+                        ""Test.B"" =>
+                            a.Select(Test.Expressions.A.ToB()) is IQueryable<TDestination> b ? b : default,
+                        _ => throw new NotSupportedException(""Projection is not configured"")
+                    };
+                default:
+                    throw new NotSupportedException(""Projection is not configured"");
+            }
+        }
+    }
+}
+");
+        }
+
+        [Test]
+        public void ProjectTo_Validation_Failed_Reports_Create_MapToAttribute_With_ProjectTo_Location()
+        {
+            GeneratorTestHelper.TestReportedDiagnosticLocation(@"using System;
+using System.Linq;
+using System.Globalization;
+using System.Threading.Tasks;
+using GeneratedMapper.Attributes;
+
+[assembly: MapperGeneratorConfiguration(GenerateEnumerableMethods = true, GenerateExpressions = true)]
+namespace Test
+{
+    public class A { public int Id { get; set; }}
+    public class B
+    {
+        public int Id { get; set; }
+        public string NotMapped { get; set; }
+    }
+
+    public class MapToClass { public B[] MapToCall() => new A[] { new() { Id = 5 } }.AsQueryable().ProjectTo<A,B>().ToArray(); }
+}",
+                "GM0017",
+                "ProjectTo<A,B>");
+        }
+    }
+}

--- a/src/GeneratedMapper/Builders/Base/ExtensionsBuilderBase.cs
+++ b/src/GeneratedMapper/Builders/Base/ExtensionsBuilderBase.cs
@@ -1,0 +1,21 @@
+﻿using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GeneratedMapper.Enums;
+using GeneratedMapper.Information;
+
+namespace GeneratedMapper.Builders.Base
+{
+    internal abstract class ExtensionsBuilderBase
+    {
+        protected readonly IEnumerable<MappingInformation> _informations;
+
+        protected ExtensionsBuilderBase(IEnumerable<MappingInformation> informations) => _informations = informations;
+
+        protected IndentedTextWriter GetIndentedWriter(StringWriter stringWriter) =>
+            new(stringWriter, _informations.First().ConfigurationValues.IndentStyle == IndentStyle.Tab
+                ? "\t"
+                : new string(' ', (int)_informations.First().ConfigurationValues.IndentSize));
+    }
+}

--- a/src/GeneratedMapper/Builders/ExpressionBuilder.cs
+++ b/src/GeneratedMapper/Builders/ExpressionBuilder.cs
@@ -16,7 +16,7 @@ namespace GeneratedMapper.Builders
 
         public ExpressionBuilder(MappingInformation information) : base(information)
         {
-            _maxRecursion = information.AttributeData.GetMaxRecursion() ?? 3;
+            _maxRecursion = information.MaxRecursion ?? 3;
         }
 
         public SourceText GenerateSourceText()

--- a/src/GeneratedMapper/Builders/MapToExtensionsBuilder.cs
+++ b/src/GeneratedMapper/Builders/MapToExtensionsBuilder.cs
@@ -1,8 +1,8 @@
-﻿using System.CodeDom.Compiler;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using GeneratedMapper.Builders.Base;
 using GeneratedMapper.Enums;
 using GeneratedMapper.Extensions;
 using GeneratedMapper.Information;
@@ -10,17 +10,14 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace GeneratedMapper.Builders
 {
-    internal sealed class MapToExtensionsBuilder
+    internal sealed class MapToExtensionsBuilder : ExtensionsBuilderBase
     {
-        private readonly IEnumerable<MappingInformation> _informations;
-
-        public MapToExtensionsBuilder(IEnumerable<MappingInformation> informations) => _informations = informations;
+        public MapToExtensionsBuilder(IEnumerable<MappingInformation> informations) : base(informations) { }
 
         public SourceText GenerateSourceText()
         {
             using var writer = new StringWriter();
-            using var indentWriter = new IndentedTextWriter(writer,
-                _informations.First().ConfigurationValues.IndentStyle == IndentStyle.Tab ? "\t" : new string(' ', (int)_informations.First().ConfigurationValues.IndentSize));
+            using var indentWriter = GetIndentedWriter(writer);
 
             indentWriter.WriteLine("using System;");
             indentWriter.WriteLine("");
@@ -56,14 +53,14 @@ namespace GeneratedMapper.Builders
                                                 indentWriter.WriteLine($"{sourceType}MapToExtensions.MapTo{mappingInformation.DestinationType.Name}({sourceField}) is TDestination {destinationField} ? {destinationField} : default,");
                                             }
                                         }
-                                        indentWriter.WriteLine("_ => throw new NotSupportedException(\"Mapping is not configured\")");
+                                        indentWriter.WriteLine("_ => throw new NotSupportedException($\"{typeof(TSource).FullName} -> {typeof(TDestination).FullName}: Map is not configured.\")");
                                     }
                                 }
                             }
                             indentWriter.WriteLine("default:");
                             using (indentWriter.Indent())
                             {
-                                indentWriter.WriteLine("throw new NotSupportedException(\"Mapping is not configured\");");
+                                indentWriter.WriteLine("throw new NotSupportedException($\"{typeof(TSource).FullName} -> {typeof(TDestination).FullName}: Map is not configured.\");");
                             }
                         }
                     }

--- a/src/GeneratedMapper/Builders/MapToExtensionsBuilder.cs
+++ b/src/GeneratedMapper/Builders/MapToExtensionsBuilder.cs
@@ -1,0 +1,76 @@
+﻿using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using GeneratedMapper.Enums;
+using GeneratedMapper.Extensions;
+using GeneratedMapper.Information;
+using Microsoft.CodeAnalysis.Text;
+
+namespace GeneratedMapper.Builders
+{
+    internal sealed class MapToExtensionsBuilder
+    {
+        private readonly IEnumerable<MappingInformation> _informations;
+
+        public MapToExtensionsBuilder(IEnumerable<MappingInformation> informations) => _informations = informations;
+
+        public SourceText GenerateSourceText()
+        {
+            using var writer = new StringWriter();
+            using var indentWriter = new IndentedTextWriter(writer,
+                _informations.First().ConfigurationValues.IndentStyle == IndentStyle.Tab ? "\t" : new string(' ', (int)_informations.First().ConfigurationValues.IndentSize));
+
+            indentWriter.WriteLine("using System;");
+            indentWriter.WriteLine("");
+            indentWriter.WriteLine("namespace GeneratedMapper.Extensions");
+            using (indentWriter.Braces())
+            {
+                indentWriter.WriteLine("public static class MapExtensions");
+                using (indentWriter.Braces())
+                {
+                    indentWriter.WriteLine("public static TDestination MapTo<TSource, TDestination>(this TSource source)");
+                    using (indentWriter.Braces())
+                    {
+                        indentWriter.WriteLine("switch (source)");
+                        using (indentWriter.Braces())
+                        {
+                            foreach (var sourceMappingInformationGroup in _informations.Where(x => x.MappingType == MappingType.ExtensionMapTo).GroupBy(x => x.SourceType))
+                            {
+                                var sourceType = sourceMappingInformationGroup.Key.ToDisplayString();
+                                var sourceField = sourceMappingInformationGroup.Key.Name.ToLower();
+                                indentWriter.WriteLine($"case {sourceType} {sourceField}:");
+                                using (indentWriter.Indent())
+                                {
+                                    indentWriter.WriteLine("return typeof(TDestination).FullName switch");
+                                    using (indentWriter.ClassSetters())
+                                    {
+                                        foreach (var mappingInformation in sourceMappingInformationGroup)
+                                        {
+                                            var destinationType = mappingInformation.DestinationType.ToDisplayString();
+                                            var destinationField = mappingInformation.DestinationType.Name.ToLower();
+                                            indentWriter.WriteLine($"\"{destinationType}\" =>");
+                                            using (indentWriter.Indent())
+                                            {
+                                                indentWriter.WriteLine($"{sourceType}MapToExtensions.MapTo{mappingInformation.DestinationType.Name}({sourceField}) is TDestination {destinationField} ? {destinationField} : default,");
+                                            }
+                                        }
+                                        indentWriter.WriteLine("_ => throw new NotSupportedException(\"Mapping is not configured\")");
+                                    }
+                                }
+                            }
+                            indentWriter.WriteLine("default:");
+                            using (indentWriter.Indent())
+                            {
+                                indentWriter.WriteLine("throw new NotSupportedException(\"Mapping is not configured\");");
+                            }
+                        }
+                    }
+                }
+            }
+
+            return SourceText.From(writer.ToString(), Encoding.UTF8);
+        }
+    }
+}

--- a/src/GeneratedMapper/Builders/MappingBuilder.cs
+++ b/src/GeneratedMapper/Builders/MappingBuilder.cs
@@ -104,7 +104,7 @@ namespace GeneratedMapper.Builders
 
         private void WriteEnumerableMapToExtensionMethod(IndentedTextWriter indentWriter)
         {
-            if (_information.ConfigurationValues.Customizations.GenerateEnumerableMethods)
+            if (_information.ConfigurationValues.Customizations.GenerateEnumerableMethods && _information.MappingType.HasFlag(MappingType.Map))
             {
                 var mapEnumerableParameters = new[] { $"this IEnumerable<{_information.SourceType?.ToDisplayString()}> {SourceInstanceName}" }
                    .Union(_mapParameterInformations.Select(x => x.ToMethodParameter(string.Empty)).Distinct());

--- a/src/GeneratedMapper/Builders/ProjectToExtensionsBuilder.cs
+++ b/src/GeneratedMapper/Builders/ProjectToExtensionsBuilder.cs
@@ -1,0 +1,77 @@
+﻿using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using GeneratedMapper.Enums;
+using GeneratedMapper.Extensions;
+using GeneratedMapper.Information;
+using Microsoft.CodeAnalysis.Text;
+
+namespace GeneratedMapper.Builders
+{
+    internal sealed class ProjectToExtensionsBuilder
+    {
+        private readonly IEnumerable<MappingInformation> _informations;
+
+        public ProjectToExtensionsBuilder(IEnumerable<MappingInformation> informations) => _informations = informations;
+
+        public SourceText GenerateSourceText()
+        {
+            using var writer = new StringWriter();
+            using var indentWriter = new IndentedTextWriter(writer,
+                _informations.First().ConfigurationValues.IndentStyle == IndentStyle.Tab ? "\t" : new string(' ', (int)_informations.First().ConfigurationValues.IndentSize));
+
+            indentWriter.WriteLine("using System;");
+            indentWriter.WriteLine("using System.Linq;");
+            indentWriter.WriteLine("");
+            indentWriter.WriteLine("namespace GeneratedMapper.Extensions");
+            using (indentWriter.Braces())
+            {
+                indentWriter.WriteLine("public static class MapExtension");
+                using (indentWriter.Braces())
+                {
+                    indentWriter.WriteLine("public static IQueryable<TDestination> ProjectTo<TSource, TDestination>(this IQueryable<TSource> source)");
+                    using (indentWriter.Braces())
+                    {
+                        indentWriter.WriteLine("switch (source)");
+                        using (indentWriter.Braces())
+                        {
+                            foreach (var sourceMappingInformationGroup in _informations.Where(x => x.MappingType == MappingType.ExtensionProjectTo).GroupBy(x => x.SourceType))
+                            {
+                                var sourceType = sourceMappingInformationGroup.Key.ToDisplayString();
+                                var sourceField = sourceMappingInformationGroup.Key.Name.ToLower();
+                                indentWriter.WriteLine($"case IQueryable<{sourceType}> {sourceField}:");
+                                using (indentWriter.Indent())
+                                {
+                                    indentWriter.WriteLine("return typeof(TDestination).FullName switch");
+                                    using (indentWriter.ClassSetters())
+                                    {
+                                        foreach (var mappingInformation in sourceMappingInformationGroup)
+                                        {
+                                            var destinationType = mappingInformation.DestinationType.ToDisplayString();
+                                            var destinationField = mappingInformation.DestinationType.Name.ToLower();
+                                            indentWriter.WriteLine($"\"{destinationType}\" =>");
+                                            using (indentWriter.Indent())
+                                            {
+                                                indentWriter.WriteLine($"{sourceField}.Select({sourceMappingInformationGroup.Key.ContainingNamespace.ToDisplayString()}.Expressions.{sourceMappingInformationGroup.Key.Name}.To{mappingInformation.DestinationType.Name}()) is IQueryable<TDestination> {destinationField} ? {destinationField} : default,");
+                                            }
+                                        }
+                                        indentWriter.WriteLine("_ => throw new NotSupportedException(\"Projection is not configured\")");
+                                    }
+                                }
+                            }
+                            indentWriter.WriteLine("default:");
+                            using (indentWriter.Indent())
+                            {
+                                indentWriter.WriteLine("throw new NotSupportedException(\"Projection is not configured\");");
+                            }
+                        }
+                    }
+                }
+            }
+
+            return SourceText.From(writer.ToString(), Encoding.UTF8);
+        }
+    }
+}

--- a/src/GeneratedMapper/Enums/MappingType.cs
+++ b/src/GeneratedMapper/Enums/MappingType.cs
@@ -2,7 +2,13 @@
 {
     internal enum MappingType
     {
-        MapFrom,
-        MapTo
+        From = 0,
+        To = 1,
+        Map = 2,
+        Project = 4,
+        MapFrom = Map | From,
+        MapTo = Map | To,
+        ExtensionMapTo = To,
+        ExtensionProjectTo = Project | MapTo
     }
 }

--- a/src/GeneratedMapper/Enums/MappingType.cs
+++ b/src/GeneratedMapper/Enums/MappingType.cs
@@ -5,10 +5,11 @@
         From = 0,
         To = 1,
         Map = 2,
-        Project = 4,
+        Extension = 4,
+        Project = 8,
         MapFrom = Map | From,
         MapTo = Map | To,
-        ExtensionMapTo = To,
-        ExtensionProjectTo = Project | MapTo
+        ExtensionMapTo = Extension | To,
+        ExtensionProjectTo = Project | To
     }
 }

--- a/src/GeneratedMapper/Helpers/DiagnosticsHelper.cs
+++ b/src/GeneratedMapper/Helpers/DiagnosticsHelper.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using System;
+using GeneratedMapper.Enums;
 
 namespace GeneratedMapper.Helpers
 {
@@ -26,6 +27,14 @@ namespace GeneratedMapper.Helpers
             Id = "GM0003",
             Title = "Property cannot be mapped",
             Message = "The type '{0}' contains the property '{1}' which cannot be found in type '{2}'. Either correct the mapping with [MapWith] or [Ignore] the property, or fix the Index of the attribute.",
+            Severity = DiagnosticSeverity.Error
+        };
+
+        private static DiagStruct _unmappablePropertyFromExtensionCall = new()
+        {
+            Id = "GM0003",
+            Title = "Property cannot be mapped",
+            Message = "The type '{0}' contains the property '{1}' which cannot be found in type '{2}'. Either correct the mapping with [MapTo(typeof())] on type and then [MapWith] or [Ignore] the property.",
             Severity = DiagnosticSeverity.Error
         };
 
@@ -139,10 +148,11 @@ namespace GeneratedMapper.Helpers
             => GetDiagnostic(_unrecognizedTypes, syntaxReference);
         public static Diagnostic UnmappableProperty(SyntaxReference syntaxReference, string attributedClass, string property, string targetClass)
             => GetDiagnostic(_unmappableProperty, syntaxReference, attributedClass, property, targetClass);
+
         public static Diagnostic IncorrectNullability(SyntaxReference syntaxReference, string sourceProperty, string destinationProperty)
             => GetDiagnostic(_incorrectNullablity, syntaxReference, sourceProperty, destinationProperty);
-        public static Diagnostic LeftOverProperty(SyntaxReference syntaxReference, string targetClass, string targetProperty, string attributedClass)
-            => GetDiagnostic(_leftOverProperty, syntaxReference, targetClass, targetProperty, attributedClass);
+        public static Diagnostic LeftOverProperty(SyntaxReference syntaxReference, string targetClass, string targetProperty, string attributedClass, MappingType mappingType)
+            => GetDiagnostic(mappingType.HasFlag(MappingType.Map) ? _leftOverProperty : _unmappablePropertyFromExtensionCall, syntaxReference, targetClass, targetProperty, attributedClass);
         public static Diagnostic CannotFindType(SyntaxReference syntaxReference, string type)
             => GetDiagnostic(_cannotFindType, syntaxReference, type);
         public static Diagnostic CannotFindMethod(SyntaxReference syntaxReference, string sourceTypeName, string sourceProperty, string methodName)

--- a/src/GeneratedMapper/Helpers/DiagnosticsHelper.cs
+++ b/src/GeneratedMapper/Helpers/DiagnosticsHelper.cs
@@ -133,38 +133,38 @@ namespace GeneratedMapper.Helpers
             Severity = DiagnosticSeverity.Error
         };
 
-        public static Diagnostic NoParameterlessConstructor(AttributeData attributeData)
-            => GetDiagnostic(_noParameterlessConstructor, attributeData);
-        public static Diagnostic UnrecognizedTypes(AttributeData attributeData)
-            => GetDiagnostic(_unrecognizedTypes, attributeData);
-        public static Diagnostic UnmappableProperty(AttributeData attributeData, string attributedClass, string property, string targetClass)
-            => GetDiagnostic(_unmappableProperty, attributeData, attributedClass, property, targetClass);
-        public static Diagnostic IncorrectNullability(AttributeData attributeData, string sourceProperty, string destinationProperty)
-            => GetDiagnostic(_incorrectNullablity, attributeData, sourceProperty, destinationProperty);
-        public static Diagnostic LeftOverProperty(AttributeData attributeData, string targetClass, string targetProperty, string attributedClass)
-            => GetDiagnostic(_leftOverProperty, attributeData, targetClass, targetProperty, attributedClass);
-        public static Diagnostic CannotFindType(AttributeData attributeData, string type)
-            => GetDiagnostic(_cannotFindType, attributeData, type);
-        public static Diagnostic CannotFindMethod(AttributeData attributeData, string sourceTypeName, string sourceProperty, string methodName)
-            => GetDiagnostic(_cannotFindMethod, attributeData, sourceTypeName, sourceProperty, methodName);
-        public static Diagnostic CannotFindTypeOfConstructorArgument(AttributeData attributeData, string argumentName, string resolverTypeName)
-            => GetDiagnostic(_cannotFindConstructorArgumentType, attributeData, argumentName, resolverTypeName);
-        public static Diagnostic UnmappableEnumerableProperty(AttributeData attributeData, string attributedClass, string property, string targetProperty, string targetClass)
-            => GetDiagnostic(_unmappableEnumerableProperty, attributeData, attributedClass, property, targetProperty, targetClass);
-        public static Diagnostic SubClassHasIncompatibleMapper(AttributeData attributeData, string sourceProperty, string destinationCollectionType)
-            => GetDiagnostic(_subClassHasIncompatibleMapper, attributeData, sourceProperty, destinationCollectionType);
-        public static Diagnostic MissingMappingInformation(AttributeData attributeData, string? mapFromType, string? mapToType)
-            => GetDiagnostic(_missingMappingInformation, attributeData, mapFromType, mapToType);
-        public static Diagnostic MultipleMappingInformation(AttributeData attributeData, string? mapFromType, string? mapToType)
-            => GetDiagnostic(_multiplewMappingInformation, attributeData, mapFromType, mapToType);
-        public static Diagnostic ConflictingMappingInformation(AttributeData attributeData, string sourceProperty)
-            => GetDiagnostic(_conflictingMappingInformation, attributeData, sourceProperty);
-        public static Diagnostic EmptyMapper(AttributeData attributeData, string sourceType, string destinationType)
-            => GetDiagnostic(_emptyMapper, attributeData, sourceType, destinationType);
-        public static Diagnostic MissingIgnoreInTarget(AttributeData attributeData, string targetType, string targetProperty)
-            => GetDiagnostic(_cannotFindPropertyToIgnore, attributeData, targetType, targetProperty);
-        public static Diagnostic CannotAwaitNull(AttributeData attributeData, string sourceType, string sourceProperty)
-            => GetDiagnostic(_cannotAwaitNull, attributeData, sourceType, sourceProperty);
+        public static Diagnostic NoParameterlessConstructor(SyntaxReference syntaxReference)
+            => GetDiagnostic(_noParameterlessConstructor, syntaxReference);
+        public static Diagnostic UnrecognizedTypes(SyntaxReference syntaxReference)
+            => GetDiagnostic(_unrecognizedTypes, syntaxReference);
+        public static Diagnostic UnmappableProperty(SyntaxReference syntaxReference, string attributedClass, string property, string targetClass)
+            => GetDiagnostic(_unmappableProperty, syntaxReference, attributedClass, property, targetClass);
+        public static Diagnostic IncorrectNullability(SyntaxReference syntaxReference, string sourceProperty, string destinationProperty)
+            => GetDiagnostic(_incorrectNullablity, syntaxReference, sourceProperty, destinationProperty);
+        public static Diagnostic LeftOverProperty(SyntaxReference syntaxReference, string targetClass, string targetProperty, string attributedClass)
+            => GetDiagnostic(_leftOverProperty, syntaxReference, targetClass, targetProperty, attributedClass);
+        public static Diagnostic CannotFindType(SyntaxReference syntaxReference, string type)
+            => GetDiagnostic(_cannotFindType, syntaxReference, type);
+        public static Diagnostic CannotFindMethod(SyntaxReference syntaxReference, string sourceTypeName, string sourceProperty, string methodName)
+            => GetDiagnostic(_cannotFindMethod, syntaxReference, sourceTypeName, sourceProperty, methodName);
+        public static Diagnostic CannotFindTypeOfConstructorArgument(SyntaxReference syntaxReference, string argumentName, string resolverTypeName)
+            => GetDiagnostic(_cannotFindConstructorArgumentType, syntaxReference, argumentName, resolverTypeName);
+        public static Diagnostic UnmappableEnumerableProperty(SyntaxReference syntaxReference, string attributedClass, string property, string targetProperty, string targetClass)
+            => GetDiagnostic(_unmappableEnumerableProperty, syntaxReference, attributedClass, property, targetProperty, targetClass);
+        public static Diagnostic SubClassHasIncompatibleMapper(SyntaxReference syntaxReference, string sourceProperty, string destinationCollectionType)
+            => GetDiagnostic(_subClassHasIncompatibleMapper, syntaxReference, sourceProperty, destinationCollectionType);
+        public static Diagnostic MissingMappingInformation(SyntaxReference syntaxReference, string? mapFromType, string? mapToType)
+            => GetDiagnostic(_missingMappingInformation, syntaxReference, mapFromType, mapToType);
+        public static Diagnostic MultipleMappingInformation(SyntaxReference syntaxReference, string? mapFromType, string? mapToType)
+            => GetDiagnostic(_multiplewMappingInformation, syntaxReference, mapFromType, mapToType);
+        public static Diagnostic ConflictingMappingInformation(SyntaxReference syntaxReference, string sourceProperty)
+            => GetDiagnostic(_conflictingMappingInformation, syntaxReference, sourceProperty);
+        public static Diagnostic EmptyMapper(SyntaxReference syntaxReference, string sourceType, string destinationType)
+            => GetDiagnostic(_emptyMapper, syntaxReference, sourceType, destinationType);
+        public static Diagnostic MissingIgnoreInTarget(SyntaxReference syntaxReference, string targetType, string targetProperty)
+            => GetDiagnostic(_cannotFindPropertyToIgnore, syntaxReference, targetType, targetProperty);
+        public static Diagnostic CannotAwaitNull(SyntaxReference syntaxReference, string sourceType, string sourceProperty)
+            => GetDiagnostic(_cannotAwaitNull, syntaxReference, sourceType, sourceProperty);
 
 
         public static Diagnostic Debug(Exception ex) => Debug($"{ex.Message } -- {ex.StackTrace.Replace("\n", "--").Replace("\r", "")}");
@@ -179,7 +179,7 @@ namespace GeneratedMapper.Helpers
                     true),
                 default);
 
-        private static Diagnostic GetDiagnostic(DiagStruct message, AttributeData attributeData, params string?[] replacements)
+        private static Diagnostic GetDiagnostic(DiagStruct message, SyntaxReference syntaxReference, params string?[] replacements)
             => Diagnostic.Create(
                 new DiagnosticDescriptor(
                     message.Id,
@@ -188,7 +188,7 @@ namespace GeneratedMapper.Helpers
                     "Usage",
                     message.Severity,
                     true),
-                attributeData?.ApplicationSyntaxReference?.GetSyntax().GetLocation());
+                syntaxReference?.GetSyntax().GetLocation());
 
         private struct DiagStruct
         {

--- a/src/GeneratedMapper/Helpers/DiagnosticsHelper.cs
+++ b/src/GeneratedMapper/Helpers/DiagnosticsHelper.cs
@@ -30,14 +30,6 @@ namespace GeneratedMapper.Helpers
             Severity = DiagnosticSeverity.Error
         };
 
-        private static DiagStruct _unmappablePropertyFromExtensionCall = new()
-        {
-            Id = "GM0003",
-            Title = "Property cannot be mapped",
-            Message = "The type '{0}' contains the property '{1}' which cannot be found in type '{2}'. Either correct the mapping with [MapTo(typeof())] on type and then [MapWith] or [Ignore] the property.",
-            Severity = DiagnosticSeverity.Error
-        };
-
         private static DiagStruct _incorrectNullablity = new()
         {
             Id = "GM0004",
@@ -139,6 +131,14 @@ namespace GeneratedMapper.Helpers
             Id = "GM0016",
             Title = "Cannot await null",
             Message = "The property '{1}' of type '{0}' is marked as nullable, which cannot be used in async mapping. Use a resolver or extension method and set IgnoreNullIncompatibility to true.",
+            Severity = DiagnosticSeverity.Error
+        };
+
+        private static DiagStruct _unmappablePropertyFromExtensionCall = new()
+        {
+            Id = "GM0017",
+            Title = "Property cannot be mapped without Attributes",
+            Message = "The type '{0}' contains the property '{1}' which cannot be found in type '{2}'. Either correct the mapping with [MapTo(typeof())] on type and then [MapWith] or [Ignore] the property.",
             Severity = DiagnosticSeverity.Error
         };
 

--- a/src/GeneratedMapper/Helpers/DiagnosticsHelper.cs
+++ b/src/GeneratedMapper/Helpers/DiagnosticsHelper.cs
@@ -142,39 +142,39 @@ namespace GeneratedMapper.Helpers
             Severity = DiagnosticSeverity.Error
         };
 
-        public static Diagnostic NoParameterlessConstructor(SyntaxReference syntaxReference)
-            => GetDiagnostic(_noParameterlessConstructor, syntaxReference);
-        public static Diagnostic UnrecognizedTypes(SyntaxReference syntaxReference)
-            => GetDiagnostic(_unrecognizedTypes, syntaxReference);
-        public static Diagnostic UnmappableProperty(SyntaxReference syntaxReference, string attributedClass, string property, string targetClass)
-            => GetDiagnostic(_unmappableProperty, syntaxReference, attributedClass, property, targetClass);
+        public static Diagnostic NoParameterlessConstructor(SyntaxNode syntaxNode)
+            => GetDiagnostic(_noParameterlessConstructor, syntaxNode);
+        public static Diagnostic UnrecognizedTypes(SyntaxNode syntaxNode)
+            => GetDiagnostic(_unrecognizedTypes, syntaxNode);
+        public static Diagnostic UnmappableProperty(SyntaxNode syntaxNode, string attributedClass, string property, string targetClass)
+            => GetDiagnostic(_unmappableProperty, syntaxNode, attributedClass, property, targetClass);
 
-        public static Diagnostic IncorrectNullability(SyntaxReference syntaxReference, string sourceProperty, string destinationProperty)
-            => GetDiagnostic(_incorrectNullablity, syntaxReference, sourceProperty, destinationProperty);
-        public static Diagnostic LeftOverProperty(SyntaxReference syntaxReference, string targetClass, string targetProperty, string attributedClass, MappingType mappingType)
-            => GetDiagnostic(mappingType.HasFlag(MappingType.Map) ? _leftOverProperty : _unmappablePropertyFromExtensionCall, syntaxReference, targetClass, targetProperty, attributedClass);
-        public static Diagnostic CannotFindType(SyntaxReference syntaxReference, string type)
-            => GetDiagnostic(_cannotFindType, syntaxReference, type);
-        public static Diagnostic CannotFindMethod(SyntaxReference syntaxReference, string sourceTypeName, string sourceProperty, string methodName)
-            => GetDiagnostic(_cannotFindMethod, syntaxReference, sourceTypeName, sourceProperty, methodName);
-        public static Diagnostic CannotFindTypeOfConstructorArgument(SyntaxReference syntaxReference, string argumentName, string resolverTypeName)
-            => GetDiagnostic(_cannotFindConstructorArgumentType, syntaxReference, argumentName, resolverTypeName);
-        public static Diagnostic UnmappableEnumerableProperty(SyntaxReference syntaxReference, string attributedClass, string property, string targetProperty, string targetClass)
-            => GetDiagnostic(_unmappableEnumerableProperty, syntaxReference, attributedClass, property, targetProperty, targetClass);
-        public static Diagnostic SubClassHasIncompatibleMapper(SyntaxReference syntaxReference, string sourceProperty, string destinationCollectionType)
-            => GetDiagnostic(_subClassHasIncompatibleMapper, syntaxReference, sourceProperty, destinationCollectionType);
-        public static Diagnostic MissingMappingInformation(SyntaxReference syntaxReference, string? mapFromType, string? mapToType)
-            => GetDiagnostic(_missingMappingInformation, syntaxReference, mapFromType, mapToType);
-        public static Diagnostic MultipleMappingInformation(SyntaxReference syntaxReference, string? mapFromType, string? mapToType)
-            => GetDiagnostic(_multiplewMappingInformation, syntaxReference, mapFromType, mapToType);
-        public static Diagnostic ConflictingMappingInformation(SyntaxReference syntaxReference, string sourceProperty)
-            => GetDiagnostic(_conflictingMappingInformation, syntaxReference, sourceProperty);
-        public static Diagnostic EmptyMapper(SyntaxReference syntaxReference, string sourceType, string destinationType)
-            => GetDiagnostic(_emptyMapper, syntaxReference, sourceType, destinationType);
-        public static Diagnostic MissingIgnoreInTarget(SyntaxReference syntaxReference, string targetType, string targetProperty)
-            => GetDiagnostic(_cannotFindPropertyToIgnore, syntaxReference, targetType, targetProperty);
-        public static Diagnostic CannotAwaitNull(SyntaxReference syntaxReference, string sourceType, string sourceProperty)
-            => GetDiagnostic(_cannotAwaitNull, syntaxReference, sourceType, sourceProperty);
+        public static Diagnostic IncorrectNullability(SyntaxNode syntaxNode, string sourceProperty, string destinationProperty)
+            => GetDiagnostic(_incorrectNullablity, syntaxNode, sourceProperty, destinationProperty);
+        public static Diagnostic LeftOverProperty(SyntaxNode syntaxNode, string targetClass, string targetProperty, string attributedClass, MappingType mappingType)
+            => GetDiagnostic(mappingType.HasFlag(MappingType.Map) ? _leftOverProperty : _unmappablePropertyFromExtensionCall, syntaxNode, targetClass, targetProperty, attributedClass);
+        public static Diagnostic CannotFindType(SyntaxNode syntaxNode, string type)
+            => GetDiagnostic(_cannotFindType, syntaxNode, type);
+        public static Diagnostic CannotFindMethod(SyntaxNode syntaxNode, string sourceTypeName, string sourceProperty, string methodName)
+            => GetDiagnostic(_cannotFindMethod, syntaxNode, sourceTypeName, sourceProperty, methodName);
+        public static Diagnostic CannotFindTypeOfConstructorArgument(SyntaxNode syntaxNode, string argumentName, string resolverTypeName)
+            => GetDiagnostic(_cannotFindConstructorArgumentType, syntaxNode, argumentName, resolverTypeName);
+        public static Diagnostic UnmappableEnumerableProperty(SyntaxNode syntaxNode, string attributedClass, string property, string targetProperty, string targetClass)
+            => GetDiagnostic(_unmappableEnumerableProperty, syntaxNode, attributedClass, property, targetProperty, targetClass);
+        public static Diagnostic SubClassHasIncompatibleMapper(SyntaxNode syntaxNode, string sourceProperty, string destinationCollectionType)
+            => GetDiagnostic(_subClassHasIncompatibleMapper, syntaxNode, sourceProperty, destinationCollectionType);
+        public static Diagnostic MissingMappingInformation(SyntaxNode syntaxNode, string? mapFromType, string? mapToType)
+            => GetDiagnostic(_missingMappingInformation, syntaxNode, mapFromType, mapToType);
+        public static Diagnostic MultipleMappingInformation(SyntaxNode syntaxNode, string? mapFromType, string? mapToType)
+            => GetDiagnostic(_multiplewMappingInformation, syntaxNode, mapFromType, mapToType);
+        public static Diagnostic ConflictingMappingInformation(SyntaxNode syntaxNode, string sourceProperty)
+            => GetDiagnostic(_conflictingMappingInformation, syntaxNode, sourceProperty);
+        public static Diagnostic EmptyMapper(SyntaxNode syntaxNode, string sourceType, string destinationType)
+            => GetDiagnostic(_emptyMapper, syntaxNode, sourceType, destinationType);
+        public static Diagnostic MissingIgnoreInTarget(SyntaxNode syntaxNode, string targetType, string targetProperty)
+            => GetDiagnostic(_cannotFindPropertyToIgnore, syntaxNode, targetType, targetProperty);
+        public static Diagnostic CannotAwaitNull(SyntaxNode syntaxNode, string sourceType, string sourceProperty)
+            => GetDiagnostic(_cannotAwaitNull, syntaxNode, sourceType, sourceProperty);
 
 
         public static Diagnostic Debug(Exception ex) => Debug($"{ex.Message } -- {ex.StackTrace.Replace("\n", "--").Replace("\r", "")}");
@@ -189,7 +189,7 @@ namespace GeneratedMapper.Helpers
                     true),
                 default);
 
-        private static Diagnostic GetDiagnostic(DiagStruct message, SyntaxReference syntaxReference, params string?[] replacements)
+        private static Diagnostic GetDiagnostic(DiagStruct message, SyntaxNode syntaxNode, params string?[] replacements)
             => Diagnostic.Create(
                 new DiagnosticDescriptor(
                     message.Id,
@@ -198,7 +198,7 @@ namespace GeneratedMapper.Helpers
                     "Usage",
                     message.Severity,
                     true),
-                syntaxReference?.GetSyntax().GetLocation());
+                syntaxNode?.GetLocation());
 
         private struct DiagStruct
         {

--- a/src/GeneratedMapper/Information/MappingInformation.cs
+++ b/src/GeneratedMapper/Information/MappingInformation.cs
@@ -13,15 +13,17 @@ namespace GeneratedMapper.Information
         private readonly List<Diagnostic> _diagnostics = new();
         private readonly List<PropertyMappingInformation> _propertyMappings = new();
 
-        public AttributeData AttributeData { get; private set; }
+        public SyntaxReference SyntaxReference { get; }
+        public int? MaxRecursion { get; }
         public ConfigurationValues ConfigurationValues { get; private set; }
         public int AttributeIndex { get; private set; }
 
-        public MappingInformation(AttributeData attributeData, ConfigurationValues configurationValues)
+        public MappingInformation(SyntaxReference syntaxReference, int? maxRecursion, int index, ConfigurationValues configurationValues)
         {
-            AttributeData = attributeData;
+            SyntaxReference = syntaxReference;
+            MaxRecursion = maxRecursion;
             ConfigurationValues = configurationValues;
-            AttributeIndex = attributeData.GetIndex();
+            AttributeIndex = index;
         }
 
         public MappingInformation ReportIssue(Diagnostic issue)
@@ -76,10 +78,10 @@ namespace GeneratedMapper.Information
         {
             if (!Mappings.Any())
             {
-                _diagnostics.Add(DiagnosticsHelper.EmptyMapper(AttributeData, SourceType?.ToDisplayString() ?? "-unknown-", DestinationType?.ToDisplayString() ?? "-unknown-"));
+                _diagnostics.Add(DiagnosticsHelper.EmptyMapper(SyntaxReference, SourceType?.ToDisplayString() ?? "-unknown-", DestinationType?.ToDisplayString() ?? "-unknown-"));
             }
 
-            _diagnostics.AddRange(Mappings.SelectMany(x => !x.TryValidateMapping(AttributeData, out var issues) ? issues : Enumerable.Empty<Diagnostic>()));
+            _diagnostics.AddRange(Mappings.SelectMany(x => !x.TryValidateMapping(SyntaxReference, out var issues) ? issues : Enumerable.Empty<Diagnostic>()));
 
             diagnostics = _diagnostics;
 

--- a/src/GeneratedMapper/Information/MappingInformation.cs
+++ b/src/GeneratedMapper/Information/MappingInformation.cs
@@ -13,7 +13,8 @@ namespace GeneratedMapper.Information
         private readonly List<Diagnostic> _diagnostics = new();
         private readonly List<PropertyMappingInformation> _propertyMappings = new();
 
-        public const int MapToIndex = int.MinValue;
+        public const int MapToIndex = ProjectToIndex - 1;
+        public const int ProjectToIndex = int.MaxValue;
 
         public SyntaxReference SyntaxReference { get; }
         public int? MaxRecursion { get; }

--- a/src/GeneratedMapper/Information/MappingInformation.cs
+++ b/src/GeneratedMapper/Information/MappingInformation.cs
@@ -16,14 +16,14 @@ namespace GeneratedMapper.Information
         public const int MapToIndex = ProjectToIndex - 1;
         public const int ProjectToIndex = int.MaxValue;
 
-        public SyntaxReference SyntaxReference { get; }
+        public SyntaxNode SyntaxNode { get; }
         public int? MaxRecursion { get; }
         public ConfigurationValues ConfigurationValues { get; private set; }
         public int AttributeIndex { get; private set; }
 
-        public MappingInformation(SyntaxReference syntaxReference, int? maxRecursion, int index, ConfigurationValues configurationValues)
+        public MappingInformation(SyntaxNode syntaxNode, int? maxRecursion, int index, ConfigurationValues configurationValues)
         {
-            SyntaxReference = syntaxReference;
+            SyntaxNode = syntaxNode;
             MaxRecursion = maxRecursion;
             ConfigurationValues = configurationValues;
             AttributeIndex = index;
@@ -119,10 +119,10 @@ namespace GeneratedMapper.Information
         {
             if (!Mappings.Any())
             {
-                _diagnostics.Add(DiagnosticsHelper.EmptyMapper(SyntaxReference, SourceType?.ToDisplayString() ?? "-unknown-", DestinationType?.ToDisplayString() ?? "-unknown-"));
+                _diagnostics.Add(DiagnosticsHelper.EmptyMapper(SyntaxNode, SourceType?.ToDisplayString() ?? "-unknown-", DestinationType?.ToDisplayString() ?? "-unknown-"));
             }
 
-            _diagnostics.AddRange(Mappings.SelectMany(x => !x.TryValidateMapping(SyntaxReference, out var issues) ? issues : Enumerable.Empty<Diagnostic>()));
+            _diagnostics.AddRange(Mappings.SelectMany(x => !x.TryValidateMapping(SyntaxNode, out var issues) ? issues : Enumerable.Empty<Diagnostic>()));
 
             diagnostics = _diagnostics;
 

--- a/src/GeneratedMapper/Information/MappingInformation.cs
+++ b/src/GeneratedMapper/Information/MappingInformation.cs
@@ -38,12 +38,7 @@ namespace GeneratedMapper.Information
                     return true;
                 }
 
-                if (ReferenceEquals(x, null))
-                {
-                    return false;
-                }
-
-                if (ReferenceEquals(y, null))
+                if (x == null || y == null)
                 {
                     return false;
                 }

--- a/src/GeneratedMapper/Information/MappingInformation.cs
+++ b/src/GeneratedMapper/Information/MappingInformation.cs
@@ -13,6 +13,8 @@ namespace GeneratedMapper.Information
         private readonly List<Diagnostic> _diagnostics = new();
         private readonly List<PropertyMappingInformation> _propertyMappings = new();
 
+        public const int MapToIndex = int.MinValue;
+
         public SyntaxReference SyntaxReference { get; }
         public int? MaxRecursion { get; }
         public ConfigurationValues ConfigurationValues { get; private set; }
@@ -25,6 +27,44 @@ namespace GeneratedMapper.Information
             ConfigurationValues = configurationValues;
             AttributeIndex = index;
         }
+
+        private sealed class SourceTypeDestinationTypeEqualityComparer : IEqualityComparer<MappingInformation>
+        {
+            public bool Equals(MappingInformation x, MappingInformation y)
+            {
+                if (ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+
+                if (ReferenceEquals(x, null))
+                {
+                    return false;
+                }
+
+                if (ReferenceEquals(y, null))
+                {
+                    return false;
+                }
+
+                if (x.GetType() != y.GetType())
+                {
+                    return false;
+                }
+
+                return Equals(x.SourceType, y.SourceType) && Equals(x.DestinationType, y.DestinationType);
+            }
+
+            public int GetHashCode(MappingInformation obj)
+            {
+                unchecked
+                {
+                    return ((obj.SourceType != null ? obj.SourceType.GetHashCode() : 0) * 397) ^ (obj.DestinationType != null ? obj.DestinationType.GetHashCode() : 0);
+                }
+            }
+        }
+
+        public static IEqualityComparer<MappingInformation> SourceTypeDestinationTypeComparer { get; } = new SourceTypeDestinationTypeEqualityComparer();
 
         public MappingInformation ReportIssue(Diagnostic issue)
         {

--- a/src/GeneratedMapper/Information/PropertyBaseMappingInformation.cs
+++ b/src/GeneratedMapper/Information/PropertyBaseMappingInformation.cs
@@ -118,27 +118,27 @@ namespace GeneratedMapper.Information
             (!string.IsNullOrEmpty(SourcePropertyMethodToCall) && !((SourceIsValueType && !SourceIsNullable) || (DestinationIsValueType && !DestinationIsNullable))) ||
             CollectionElements.Any(x => x.RequiresNullableContext);
 
-        public bool TryValidateMapping(SyntaxReference syntaxReference, out IEnumerable<Diagnostic> diagnostics)
+        public bool TryValidateMapping(SyntaxNode syntaxNode, out IEnumerable<Diagnostic> diagnostics)
         {
             var messages = new List<Diagnostic>();
 
-            messages.AddRange(Validate(syntaxReference, MapWithAttribute));
+            messages.AddRange(Validate(syntaxNode, MapWithAttribute));
 
             if (RequiresMappingInformationOfMapper && MappingInformationOfMapperToUse == null)
             {
-                messages.Add(DiagnosticsHelper.MissingMappingInformation(syntaxReference, MapperFromType?.ToDisplayString(), MapperToType?.ToDisplayString()));
+                messages.Add(DiagnosticsHelper.MissingMappingInformation(syntaxNode, MapperFromType?.ToDisplayString(), MapperToType?.ToDisplayString()));
             }
 
             foreach (var element in CollectionElements)
             {
-                messages.AddRange(element.Validate(syntaxReference, MapWithAttribute));
+                messages.AddRange(element.Validate(syntaxNode, MapWithAttribute));
             }
 
             diagnostics = messages;
             return messages.Count == 0;
         }
 
-        protected virtual IEnumerable<Diagnostic> Validate(SyntaxReference syntaxReference, AttributeData? mapWithAttributeData) => Enumerable.Empty<Diagnostic>();
+        protected virtual IEnumerable<Diagnostic> Validate(SyntaxNode syntaxNode, AttributeData? mapWithAttributeData) => Enumerable.Empty<Diagnostic>();
 
         private IEnumerable<ParameterInformation> AllParameters
         {

--- a/src/GeneratedMapper/Information/PropertyBaseMappingInformation.cs
+++ b/src/GeneratedMapper/Information/PropertyBaseMappingInformation.cs
@@ -118,27 +118,27 @@ namespace GeneratedMapper.Information
             (!string.IsNullOrEmpty(SourcePropertyMethodToCall) && !((SourceIsValueType && !SourceIsNullable) || (DestinationIsValueType && !DestinationIsNullable))) ||
             CollectionElements.Any(x => x.RequiresNullableContext);
 
-        public bool TryValidateMapping(AttributeData attributeData, out IEnumerable<Diagnostic> diagnostics)
+        public bool TryValidateMapping(SyntaxReference syntaxReference, out IEnumerable<Diagnostic> diagnostics)
         {
             var messages = new List<Diagnostic>();
 
-            messages.AddRange(Validate(attributeData, MapWithAttribute));
+            messages.AddRange(Validate(syntaxReference, MapWithAttribute));
 
             if (RequiresMappingInformationOfMapper && MappingInformationOfMapperToUse == null)
             {
-                messages.Add(DiagnosticsHelper.MissingMappingInformation(attributeData, MapperFromType?.ToDisplayString(), MapperToType?.ToDisplayString()));
+                messages.Add(DiagnosticsHelper.MissingMappingInformation(syntaxReference, MapperFromType?.ToDisplayString(), MapperToType?.ToDisplayString()));
             }
 
             foreach (var element in CollectionElements)
             {
-                messages.AddRange(element.Validate(attributeData, MapWithAttribute));
+                messages.AddRange(element.Validate(syntaxReference, MapWithAttribute));
             }
 
             diagnostics = messages;
             return messages.Count == 0;
         }
 
-        protected virtual IEnumerable<Diagnostic> Validate(AttributeData mapAttributeData, AttributeData? mapWithAttributeData) => Enumerable.Empty<Diagnostic>();
+        protected virtual IEnumerable<Diagnostic> Validate(SyntaxReference syntaxReference, AttributeData? mapWithAttributeData) => Enumerable.Empty<Diagnostic>();
 
         private IEnumerable<ParameterInformation> AllParameters
         {

--- a/src/GeneratedMapper/Information/PropertyElementMappingInformation.cs
+++ b/src/GeneratedMapper/Information/PropertyElementMappingInformation.cs
@@ -47,11 +47,11 @@ namespace GeneratedMapper.Information
             DestinationFieldName = field.Name;
         }
 
-        protected override IEnumerable<Diagnostic> Validate(AttributeData mapAttributeData, AttributeData? mapWithAttributeData)
+        protected override IEnumerable<Diagnostic> Validate(SyntaxReference syntaxReference, AttributeData? mapWithAttributeData)
         {
             if (string.IsNullOrWhiteSpace(SourceTypeName) || string.IsNullOrWhiteSpace(DestinationTypeName))
             {
-                yield return DiagnosticsHelper.UnrecognizedTypes(mapAttributeData);
+                yield return DiagnosticsHelper.UnrecognizedTypes(syntaxReference);
             }
         }
     }

--- a/src/GeneratedMapper/Information/PropertyElementMappingInformation.cs
+++ b/src/GeneratedMapper/Information/PropertyElementMappingInformation.cs
@@ -47,11 +47,11 @@ namespace GeneratedMapper.Information
             DestinationFieldName = field.Name;
         }
 
-        protected override IEnumerable<Diagnostic> Validate(SyntaxReference syntaxReference, AttributeData? mapWithAttributeData)
+        protected override IEnumerable<Diagnostic> Validate(SyntaxNode syntaxNode, AttributeData? mapWithAttributeData)
         {
             if (string.IsNullOrWhiteSpace(SourceTypeName) || string.IsNullOrWhiteSpace(DestinationTypeName))
             {
-                yield return DiagnosticsHelper.UnrecognizedTypes(syntaxReference);
+                yield return DiagnosticsHelper.UnrecognizedTypes(syntaxNode);
             }
         }
     }

--- a/src/GeneratedMapper/Information/PropertyMappingInformation.cs
+++ b/src/GeneratedMapper/Information/PropertyMappingInformation.cs
@@ -59,21 +59,21 @@ namespace GeneratedMapper.Information
             CollectionElements.Add(element);
         }
 
-        protected override IEnumerable<Diagnostic> Validate(AttributeData mapAttributeData, AttributeData? mapWithAttributeData)
+        protected override IEnumerable<Diagnostic> Validate(SyntaxReference syntaxReference, AttributeData? mapWithAttributeData)
         {
             if (string.IsNullOrWhiteSpace(SourcePropertyName) || string.IsNullOrWhiteSpace(DestinationPropertyName))
             {
-                yield return DiagnosticsHelper.UnrecognizedTypes(mapAttributeData);
+                yield return DiagnosticsHelper.UnrecognizedTypes(syntaxReference);
             }
 
             if (SourceIsNullable && !DestinationIsNullable && PropertyType == default && mapWithAttributeData?.GetIgnoreNullIncompatibility() != true)
             {
-                yield return DiagnosticsHelper.IncorrectNullability(mapAttributeData, SourcePropertyName!, DestinationPropertyName!);
+                yield return DiagnosticsHelper.IncorrectNullability(syntaxReference, SourcePropertyName!, DestinationPropertyName!);
             }
 
             if (SourceIsNullable && IsAsync && mapWithAttributeData?.GetIgnoreNullIncompatibility() != true)
             {
-                yield return DiagnosticsHelper.CannotAwaitNull(mapAttributeData, BelongsToMapping.SourceType?.Name!, SourcePropertyName!);
+                yield return DiagnosticsHelper.CannotAwaitNull(syntaxReference, BelongsToMapping.SourceType?.Name!, SourcePropertyName!);
             }
 
             if ((!string.IsNullOrWhiteSpace(ResolverTypeToUse) && !string.IsNullOrWhiteSpace(SourcePropertyMethodToCall)) ||
@@ -81,7 +81,7 @@ namespace GeneratedMapper.Information
                 (!string.IsNullOrWhiteSpace(SourcePropertyMethodToCall) && RequiresMappingInformationOfMapper) ||
                 (SourceIsValueType != DestinationIsValueType && string.IsNullOrWhiteSpace(ResolverTypeToUse) && string.IsNullOrWhiteSpace(SourcePropertyMethodToCall) && !RequiresMappingInformationOfMapper))
             {
-                yield return DiagnosticsHelper.ConflictingMappingInformation(mapAttributeData, SourcePropertyName!);
+                yield return DiagnosticsHelper.ConflictingMappingInformation(syntaxReference, SourcePropertyName!);
             }
         }
     }

--- a/src/GeneratedMapper/Information/PropertyMappingInformation.cs
+++ b/src/GeneratedMapper/Information/PropertyMappingInformation.cs
@@ -59,21 +59,21 @@ namespace GeneratedMapper.Information
             CollectionElements.Add(element);
         }
 
-        protected override IEnumerable<Diagnostic> Validate(SyntaxReference syntaxReference, AttributeData? mapWithAttributeData)
+        protected override IEnumerable<Diagnostic> Validate(SyntaxNode syntaxNode, AttributeData? mapWithAttributeData)
         {
             if (string.IsNullOrWhiteSpace(SourcePropertyName) || string.IsNullOrWhiteSpace(DestinationPropertyName))
             {
-                yield return DiagnosticsHelper.UnrecognizedTypes(syntaxReference);
+                yield return DiagnosticsHelper.UnrecognizedTypes(syntaxNode);
             }
 
             if (SourceIsNullable && !DestinationIsNullable && PropertyType == default && mapWithAttributeData?.GetIgnoreNullIncompatibility() != true)
             {
-                yield return DiagnosticsHelper.IncorrectNullability(syntaxReference, SourcePropertyName!, DestinationPropertyName!);
+                yield return DiagnosticsHelper.IncorrectNullability(syntaxNode, SourcePropertyName!, DestinationPropertyName!);
             }
 
             if (SourceIsNullable && IsAsync && mapWithAttributeData?.GetIgnoreNullIncompatibility() != true)
             {
-                yield return DiagnosticsHelper.CannotAwaitNull(syntaxReference, BelongsToMapping.SourceType?.Name!, SourcePropertyName!);
+                yield return DiagnosticsHelper.CannotAwaitNull(syntaxNode, BelongsToMapping.SourceType?.Name!, SourcePropertyName!);
             }
 
             if ((!string.IsNullOrWhiteSpace(ResolverTypeToUse) && !string.IsNullOrWhiteSpace(SourcePropertyMethodToCall)) ||
@@ -81,7 +81,7 @@ namespace GeneratedMapper.Information
                 (!string.IsNullOrWhiteSpace(SourcePropertyMethodToCall) && RequiresMappingInformationOfMapper) ||
                 (SourceIsValueType != DestinationIsValueType && string.IsNullOrWhiteSpace(ResolverTypeToUse) && string.IsNullOrWhiteSpace(SourcePropertyMethodToCall) && !RequiresMappingInformationOfMapper))
             {
-                yield return DiagnosticsHelper.ConflictingMappingInformation(syntaxReference, SourcePropertyName!);
+                yield return DiagnosticsHelper.ConflictingMappingInformation(syntaxNode, SourcePropertyName!);
             }
         }
     }

--- a/src/GeneratedMapper/Information/PropertyMappingInformation.cs
+++ b/src/GeneratedMapper/Information/PropertyMappingInformation.cs
@@ -74,7 +74,7 @@ namespace GeneratedMapper.Information
 
                 if (!ignoreExplicitly && (!usesResolver || (usesResolver && dotNotIgnoreExplicitly)))
                 {
-                    yield return DiagnosticsHelper.IncorrectNullability(mapAttributeData, SourcePropertyName!, DestinationPropertyName!);
+                    yield return DiagnosticsHelper.IncorrectNullability(syntaxNode, SourcePropertyName!, DestinationPropertyName!);
                 }
             }
 

--- a/src/GeneratedMapper/MapperGenerator.cs
+++ b/src/GeneratedMapper/MapperGenerator.cs
@@ -99,12 +99,12 @@ namespace GeneratedMapper
                         foreach (var match in attributeReceiver.ExtensionCandidates.Where(x => x.Source == candidateTypeNode))
                         {
                             var target = context.Compilation.GetSemanticModel(match.Destination.SyntaxTree).GetDeclaredSymbol(match.Destination);
-                            foundMappings.Add(parser.ParseAttribute(configurationValues, candidateTypeSymbol, MappingType.ExtensionMapTo, null, MappingInformation.MapToIndex, candidateTypeSymbol as INamedTypeSymbol, target as INamedTypeSymbol, null, afterMapMethods));
+                           foundMappings.Add(parser.ParseAttribute(configurationValues, candidateTypeSymbol, MappingType.ExtensionMapTo, null, MappingInformation.MapToIndex, candidateTypeSymbol as INamedTypeSymbol, target as INamedTypeSymbol, match.Syntax, afterMapMethods));
                         }
                         foreach (var match in attributeReceiver.ProjectionCanidates.Where(x => x.Source == candidateTypeNode))
                         {
                             var target = context.Compilation.GetSemanticModel(match.Destination.SyntaxTree).GetDeclaredSymbol(match.Destination);
-                            foundMappings.Add(parser.ParseAttribute(configurationValues, candidateTypeSymbol, MappingType.ExtensionProjectTo, null, MappingInformation.ProjectToIndex, candidateTypeSymbol as INamedTypeSymbol, target as INamedTypeSymbol, null, afterMapMethods));
+                            foundMappings.Add(parser.ParseAttribute(configurationValues, candidateTypeSymbol, MappingType.ExtensionProjectTo, null, MappingInformation.ProjectToIndex, candidateTypeSymbol as INamedTypeSymbol, target as INamedTypeSymbol, match.Syntax, afterMapMethods));
                         }
 
                         foundMappings.AddRange(
@@ -119,7 +119,7 @@ namespace GeneratedMapper
                                     var attributeType = attribute.ConstructorArgument<INamedTypeSymbol>(0);
                                     return parser.ParseAttribute(configurationValues, candidateTypeSymbol,
                                         mapFrom ? MappingType.MapFrom : MappingType.MapTo, attribute.GetMaxRecursion(),
-                                        attribute.GetIndex(), mapFrom ? attributeType : candidateTypeSymbol as INamedTypeSymbol, mapFrom ? candidateTypeSymbol as INamedTypeSymbol : attributeType, attribute.ApplicationSyntaxReference, afterMapMethods);
+                                        attribute.GetIndex(), mapFrom ? attributeType : candidateTypeSymbol as INamedTypeSymbol, mapFrom ? candidateTypeSymbol as INamedTypeSymbol : attributeType, attribute.ApplicationSyntaxReference.GetSyntax(), afterMapMethods);
                                 }));
                     }
                 }
@@ -256,7 +256,7 @@ namespace GeneratedMapper
                 }
                 else
                 {
-                    mapping.BelongsToMapping.ReportIssue(DiagnosticsHelper.MultipleMappingInformation(mapping.BelongsToMapping.SyntaxReference, mapping.MapperFromType?.ToDisplayString(), mapping.MapperToType?.ToDisplayString()));
+                    mapping.BelongsToMapping.ReportIssue(DiagnosticsHelper.MultipleMappingInformation(mapping.BelongsToMapping.SyntaxNode, mapping.MapperFromType?.ToDisplayString(), mapping.MapperToType?.ToDisplayString()));
                 }
             }
         }

--- a/src/GeneratedMapper/MapperGenerator.cs
+++ b/src/GeneratedMapper/MapperGenerator.cs
@@ -285,7 +285,7 @@ namespace GeneratedMapper
                     yield return ($"{information.SourceType.Name}_To_{information.DestinationType.Name}_Map.g.cs", text);
                 }
 
-                if (information.ConfigurationValues.Customizations.GenerateExpressions || mappingType.HasFlag(MappingType.Project))
+                if (information.ConfigurationValues.Customizations.GenerateExpressions && mappingType.HasFlag(MappingType.Map) || mappingType.HasFlag(MappingType.Project))
                 {
                     var expressionText = new ExpressionBuilder(information).GenerateSourceText();
                     yield return ($"{information.SourceType.Name}_To_{information.DestinationType.Name}_Expression.g.cs", expressionText);

--- a/src/GeneratedMapper/Parsers/MappingAttributeParser.cs
+++ b/src/GeneratedMapper/Parsers/MappingAttributeParser.cs
@@ -36,7 +36,7 @@ namespace GeneratedMapper.Parsers
             SyntaxReference syntaxReference, List<AfterMapInformation> afterMapInformations)
         {
             var mappingInformation = new MappingInformation(syntaxReference, maxRecursion, index, configurationValues);
-            var targetType = mappingType == MappingType.MapTo ? destinationType : sourceType;
+            var targetType = mappingType.HasFlag(MappingType.To) ? destinationType : sourceType;
             try
             {
                 mappingInformation.MapType(mappingType);
@@ -55,8 +55,8 @@ namespace GeneratedMapper.Parsers
 
                 var destinationPropertyExclusions = TargetPropertiesToIgnore(attributedType, mappingInformation.AttributeIndex);
 
-                var attributedTypeProperties = mappingType == MappingType.MapTo ? GetMappableGetPropertiesOfType(attributedType) : GetMappableSetPropertiesOfType(attributedType);
-                var targetTypeProperties = mappingType == MappingType.MapFrom ? GetMappableGetPropertiesOfType(targetType) : GetMappableSetPropertiesOfType(targetType);
+                var attributedTypeProperties = mappingType.HasFlag(MappingType.To) ? GetMappableGetPropertiesOfType(attributedType) : GetMappableSetPropertiesOfType(attributedType);
+                var targetTypeProperties = !mappingType.HasFlag(MappingType.To) ? GetMappableGetPropertiesOfType(targetType) : GetMappableSetPropertiesOfType(targetType);
                 
                 foreach (var targetTypeProperty in destinationPropertyExclusions.Where(name => !targetTypeProperties.ContainsKey(name)))
                 {
@@ -121,7 +121,7 @@ namespace GeneratedMapper.Parsers
 
                 foreach (var remainingTargetProperty in targetTypeProperties.Where(x => !destinationPropertyExclusions.Contains(x.Key) && !processedTargetProperties.Contains(x.Key)))
                 {
-                    mappingInformation.ReportIssue(DiagnosticsHelper.LeftOverProperty(syntaxReference, targetType.ToDisplayString(), remainingTargetProperty.Key, attributedType.ToDisplayString()));
+                    mappingInformation.ReportIssue(DiagnosticsHelper.LeftOverProperty(syntaxReference, targetType.ToDisplayString(), remainingTargetProperty.Key, attributedType.ToDisplayString(), mappingType));
                 }
 
                 foreach (var afterMap in afterMapInformations.Where(am =>

--- a/src/GeneratedMapper/Parsers/MappingAttributeParser.cs
+++ b/src/GeneratedMapper/Parsers/MappingAttributeParser.cs
@@ -33,9 +33,9 @@ namespace GeneratedMapper.Parsers
         public MappingInformation ParseAttribute(ConfigurationValues configurationValues, ITypeSymbol attributedType,
             MappingType mappingType, int? maxRecursion, int index, INamedTypeSymbol sourceType,
             INamedTypeSymbol destinationType,
-            SyntaxReference syntaxReference, List<AfterMapInformation> afterMapInformations)
+            SyntaxNode syntaxNode, List<AfterMapInformation> afterMapInformations)
         {
-            var mappingInformation = new MappingInformation(syntaxReference, maxRecursion, index, configurationValues);
+            var mappingInformation = new MappingInformation(syntaxNode, maxRecursion, index, configurationValues);
             var targetType = mappingType.HasFlag(MappingType.To) ? destinationType : sourceType;
             try
             {
@@ -43,12 +43,12 @@ namespace GeneratedMapper.Parsers
 
                 if (sourceType == null || destinationType == null)
                 {
-                    throw new ParseException(DiagnosticsHelper.UnrecognizedTypes(syntaxReference));
+                    throw new ParseException(DiagnosticsHelper.UnrecognizedTypes(syntaxNode));
                 }
 
                 if (!destinationType.Constructors.Any(x => x.DeclaredAccessibility == Accessibility.Public && x.Parameters.Length == 0))
                 {
-                    throw new ParseException(DiagnosticsHelper.NoParameterlessConstructor(syntaxReference));
+                    throw new ParseException(DiagnosticsHelper.NoParameterlessConstructor(syntaxNode));
                 }
 
                 mappingInformation.MapFrom(sourceType).MapTo(destinationType);
@@ -60,7 +60,7 @@ namespace GeneratedMapper.Parsers
                 
                 foreach (var targetTypeProperty in destinationPropertyExclusions.Where(name => !targetTypeProperties.ContainsKey(name)))
                 {
-                    mappingInformation.ReportIssue(DiagnosticsHelper.MissingIgnoreInTarget(syntaxReference, destinationType.ToDisplayString(), targetTypeProperty));
+                    mappingInformation.ReportIssue(DiagnosticsHelper.MissingIgnoreInTarget(syntaxNode, destinationType.ToDisplayString(), targetTypeProperty));
                 }
 
                 var processedTargetProperties = new List<string>();
@@ -81,7 +81,7 @@ namespace GeneratedMapper.Parsers
                         {
                             var property = _propertyParser.ParseNestedProperty(
                                 mappingInformation, 
-                                mapWithAttribute ?? throw new ParseException(DiagnosticsHelper.UnmappableProperty(syntaxReference, sourceType.Name, targetPropertyToFind, destinationType.Name)),
+                                mapWithAttribute ?? throw new ParseException(DiagnosticsHelper.UnmappableProperty(syntaxNode, sourceType.Name, targetPropertyToFind, destinationType.Name)),
                                 targetPropertyToFind,
                                 attributedTypePropertySet.First());
 
@@ -91,7 +91,7 @@ namespace GeneratedMapper.Parsers
                         {
                             if (!targetTypeProperties.ContainsKey(targetPropertyToFind))
                             {
-                                mappingInformation.ReportIssue(DiagnosticsHelper.UnmappableProperty(syntaxReference, attributedType.ToDisplayString(), targetPropertyToFind, targetType.ToDisplayString()));
+                                mappingInformation.ReportIssue(DiagnosticsHelper.UnmappableProperty(syntaxNode, attributedType.ToDisplayString(), targetPropertyToFind, targetType.ToDisplayString()));
                                 continue;
                             }
                             var targetTypePropertySet = targetTypeProperties[targetPropertyToFind];
@@ -100,7 +100,7 @@ namespace GeneratedMapper.Parsers
 
                             if (mappingInformation.Mappings.Any(x => x.DestinationPropertyName == property.DestinationPropertyName))
                             {
-                                mappingInformation.ReportIssue(DiagnosticsHelper.ConflictingMappingInformation(syntaxReference, property.SourcePropertyName!));
+                                mappingInformation.ReportIssue(DiagnosticsHelper.ConflictingMappingInformation(syntaxNode, property.SourcePropertyName!));
                             }
                             else
                             {
@@ -121,7 +121,7 @@ namespace GeneratedMapper.Parsers
 
                 foreach (var remainingTargetProperty in targetTypeProperties.Where(x => !destinationPropertyExclusions.Contains(x.Key) && !processedTargetProperties.Contains(x.Key)))
                 {
-                    mappingInformation.ReportIssue(DiagnosticsHelper.LeftOverProperty(syntaxReference, targetType.ToDisplayString(), remainingTargetProperty.Key, attributedType.ToDisplayString(), mappingType));
+                    mappingInformation.ReportIssue(DiagnosticsHelper.LeftOverProperty(syntaxNode, targetType.ToDisplayString(), remainingTargetProperty.Key, attributedType.ToDisplayString(), mappingType));
                 }
 
                 foreach (var afterMap in afterMapInformations.Where(am =>

--- a/src/GeneratedMapper/Parsers/PropertyParser.cs
+++ b/src/GeneratedMapper/Parsers/PropertyParser.cs
@@ -158,7 +158,7 @@ namespace GeneratedMapper.Parsers
             else
             {
                 // this is never hit
-                throw new ParseException(DiagnosticsHelper.UnmappableEnumerableProperty(propertyMapping.BelongsToMapping.AttributeData,
+                throw new ParseException(DiagnosticsHelper.UnmappableEnumerableProperty(propertyMapping.BelongsToMapping.SyntaxReference,
                     propertyMapping.BelongsToMapping.SourceType?.ToDisplayString()!,
                     propertyMapping.SourcePropertyName!,
                     propertyMapping.BelongsToMapping.DestinationType?.ToDisplayString()!,

--- a/src/GeneratedMapper/Parsers/PropertyParser.cs
+++ b/src/GeneratedMapper/Parsers/PropertyParser.cs
@@ -158,7 +158,7 @@ namespace GeneratedMapper.Parsers
             else
             {
                 // this is never hit
-                throw new ParseException(DiagnosticsHelper.UnmappableEnumerableProperty(propertyMapping.BelongsToMapping.SyntaxReference,
+                throw new ParseException(DiagnosticsHelper.UnmappableEnumerableProperty(propertyMapping.BelongsToMapping.SyntaxNode,
                     propertyMapping.BelongsToMapping.SourceType?.ToDisplayString()!,
                     propertyMapping.SourcePropertyName!,
                     propertyMapping.BelongsToMapping.DestinationType?.ToDisplayString()!,

--- a/src/GeneratedMapper/SyntaxReceivers/ExtensionCandidate.cs
+++ b/src/GeneratedMapper/SyntaxReceivers/ExtensionCandidate.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace GeneratedMapper.SyntaxReceivers
+{
+    internal sealed class ExtensionCandidate
+    {
+        public ExtensionCandidate(TypeDeclarationSyntax source, TypeDeclarationSyntax destination, GenericNameSyntax syntax)
+        {
+            Source = source;
+            Destination = destination;
+            Syntax = syntax;
+        }
+
+        public TypeDeclarationSyntax Source { get; }
+        public TypeDeclarationSyntax Destination { get; }
+        public GenericNameSyntax Syntax { get; }
+    }
+}

--- a/src/GeneratedMapper/SyntaxReceivers/ExtensionMapCandidate.cs
+++ b/src/GeneratedMapper/SyntaxReceivers/ExtensionMapCandidate.cs
@@ -2,7 +2,7 @@
 
 namespace GeneratedMapper.SyntaxReceivers
 {
-    public class ExtensionMapCandidate
+    internal sealed class ExtensionMapCandidate
     {
         private readonly GenericNameSyntax _genericNameSyntax;
 

--- a/src/GeneratedMapper/SyntaxReceivers/ExtensionMapCandidate.cs
+++ b/src/GeneratedMapper/SyntaxReceivers/ExtensionMapCandidate.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace GeneratedMapper.SyntaxReceivers
+{
+    public class ExtensionMapCandidate
+    {
+        private readonly GenericNameSyntax _genericNameSyntax;
+
+        public ExtensionMapCandidate(GenericNameSyntax genericNameSyntax) => _genericNameSyntax = genericNameSyntax;
+
+        public GenericNameSyntax Syntax => _genericNameSyntax;
+        public TypeSyntax Source => _genericNameSyntax.TypeArgumentList.Arguments[0];
+        public TypeSyntax Destination  => _genericNameSyntax.TypeArgumentList.Arguments[1];
+    }
+}

--- a/src/GeneratedMapper/SyntaxReceivers/MapAttributeReceiver.cs
+++ b/src/GeneratedMapper/SyntaxReceivers/MapAttributeReceiver.cs
@@ -13,6 +13,8 @@ namespace GeneratedMapper.SyntaxReceivers
         private readonly List<TypeDeclarationSyntax> _cachedSyntaxes = new();
         public List<ExtensionCandidate> ExtensionCandidates { get; } = new();
         private readonly List<ExtensionMapCandidate> _extensionCandidates = new();
+        public List<ExtensionCandidate> ProjectionCanidates { get; } = new();
+        private readonly List<ExtensionMapCandidate> _projectionCandidates = new();
 
         public List<TypeDeclarationSyntax> ClassesWithExtensionMethods { get; } = new();
         public List<TypeDeclarationSyntax> ClassesWithAfterMapMethods { get; } = new();
@@ -51,9 +53,17 @@ namespace GeneratedMapper.SyntaxReceivers
 
             if (syntaxNode is MemberAccessExpressionSyntax memberAccessExpressionSyntax)
             {
-                if (memberAccessExpressionSyntax.Name.Identifier.Text == "MapTo" && memberAccessExpressionSyntax.Name is GenericNameSyntax nameSyntax && nameSyntax.TypeArgumentList.Arguments.Count == 2)
+                if (memberAccessExpressionSyntax.Name is GenericNameSyntax nameSyntax && nameSyntax.TypeArgumentList.Arguments.Count == 2)
                 {
-                    _extensionCandidates.Add(new ExtensionMapCandidate(nameSyntax));
+                    switch (memberAccessExpressionSyntax.Name.Identifier.Text)
+                    {
+                        case "MapTo":
+                            _extensionCandidates.Add(new ExtensionMapCandidate(nameSyntax));
+                            break;
+                        case "ProjectTo":
+                            _projectionCandidates.Add(new ExtensionMapCandidate(nameSyntax));
+                            break;
+                    }
                 }
                 //Todo: Add check here to see if method call is generic and calls MapTo in sub callings
                 // Then add to extension candidate with Generic arguments correctly assigned
@@ -71,6 +81,17 @@ namespace GeneratedMapper.SyntaxReceivers
                 }
                 ExtensionCandidates.Add(new ExtensionCandidate(match, _cachedSyntaxes.FirstOrDefault(x => x.Identifier.Text == (extensionCandidate.Destination as IdentifierNameSyntax)?.Identifier.Text), extensionCandidate.Syntax));
             }
+
+            foreach (var projectionCandidate in _projectionCandidates)
+            {
+                var match = _cachedSyntaxes.FirstOrDefault(x => x.Identifier.Text == (projectionCandidate.Source as IdentifierNameSyntax)?.Identifier.Text);
+                if (!Candidates.Contains(match))
+                {
+                    Candidates.Add(match);
+                }
+                ProjectionCanidates.Add(new ExtensionCandidate(match, _cachedSyntaxes.FirstOrDefault(x => x.Identifier.Text == (projectionCandidate.Destination as IdentifierNameSyntax)?.Identifier.Text), projectionCandidate.Syntax));
+            }
+
             _cachedSyntaxes.Clear();
         }
     }


### PR DESCRIPTION
This is an early work in progress but the idea is to show how using code the user writes can generate the mapping code for them automatically without the need for attributes in the most simplest of cases.  This is by no means finished and there's a lot of bugs that need to be ironed out, but the basic gist is there.

From this you only generate code based on what you actually use and not just configure.  The idea is going further that you might be able to further remove configuration settings, or at least eliminate un-used code for things that aren't being generated.
- Ex:  If you just use Projection method calls and never Map then it only generates Expression code and never map to code, since it's never being used.  But once the user writes a call to Map something, the code will then be generated for them.

### Changes
Make code using existing `MapperInformation` system and modifying to not work exclusively off of attribute mappings.
- `MapTo<,>`call will generate base code that will throw exception
- When user makes a call to it, then will auto generate `MapperInformation` for source and destination types
- The new mapping function will then add a switch statement for mapping said types and check source type and map to destination if match.

### Todos
- [x] Make switch statement only use the Types that were called from source code
  - Currently using All `MappingInformation` made, except ones with `AfterMap` because code doesn't compile.
  - No need to have all `MappingInformation`s in the switch statement if user's code won't ever reach it.
 - [x] Handle one source to multiple destinations being called in the `MapTo<,>`
  - Checks source type but not destination type for what should be returned
  - might have to move out of a switch statement depending on how it works, but uses switch right now because it's more optimized then a bunch of if statements.

- [x] Handle Configurations where both Attributes and `MapTo<,>` extension calls are used for the same `MapperInformation`
  - Currently only works for one or the other, and will double add if both are there
    - If you have Map attributes in the properties but not the Type, the system should be able to pick them up if index match
  - Need to detect if mapping already exists with Attributes and ignore, else add at the end and make sure index is +1 max mapping used from source if it doesn't already exist
  - Also need to update SyntaxReference for `MapTo<,>` validation errors calls since the source of the error isn't an attribute but a method call for the Diagnostics section
    - If use both Attributes and method calls are set will default to Attribute and errors will be shown in that location only
- [x] Figure out how to handle `MappingInformation` when using `MapTo<,>` extension method with additional constructor arguments
  - Currently blocked by simple filter for AfterMaps so can get simple scenario to work.
  - How best to notify the user, because right now the auto generated code fails with argument counts not matching exception which will confuse the user
    - I think for these cases it's probably best to use default MapToDest method calls since they will have all the parameters guaranteed.
    - Maybe tell the user a `MapTo<,>` call is using additional parameters and can't be called from there, and don't add code.
- [x] Support for Projection by method call
  - Do same thing but have method like `ProjectTo<,>` that will look for Types and generate the Expression switching between the Types
  - Maybe do the same with Enumerable mappings